### PR TITLE
feat(ci): promote images from staging when deploying to prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           HAPPY_OIDC_ID_TOKEN=${{env.id_token}} happy config set API_URL ${{ vars.API_URL }} --env prod --aws-profile ""
       - name: Deploy to production env
-        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@main
+        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.26.0
         with:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: ${{ vars.HAPPY_ENV }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: ${{ vars.HAPPY_ENV }}
-          create-tag: true
+          image-source-env: ${{ vars.IMAGE_SOURCE_ENV }}
+          image-source-stack: ${{ secrets.IMAGE_SOURCE_STACK }}
+          image-source-role-arn: ${{ secrets.IMAGE_SOURCE_ROLE_ARN }}
           stack-name: ${{ secrets.HAPPY_STACK_NAME }}
           version-lock-file: .happy/version.lock

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           HAPPY_OIDC_ID_TOKEN=${{env.id_token}} happy config set API_URL ${{ vars.API_URL }} --env sandbox --aws-profile ""
       - name: Update sandbox
-        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@main
+        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.26.0
         with:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: ${{ vars.HAPPY_ENV }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           HAPPY_OIDC_ID_TOKEN=${{env.id_token}} happy config set API_URL ${{ vars.API_URL }} --env staging --aws-profile ""
       - name: Deploy to staging env
-        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@main
+        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.26.0
         with:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: ${{ vars.HAPPY_ENV }}

--- a/.happy/version.lock
+++ b/.happy/version.lock
@@ -1,5 +1,5 @@
 {
   "Require": {
-    "chanzuckerberg/happy": "0.110.1"
+    "chanzuckerberg/happy": "0.114.1"
  }
 }

--- a/.happy/version.lock
+++ b/.happy/version.lock
@@ -1,5 +1,5 @@
 {
   "Require": {
-    "chanzuckerberg/happy": "0.114.1"
+    "chanzuckerberg/happy": "0.118.2"
  }
 }


### PR DESCRIPTION
# Pull Request
[CZID-8804]

## Description
Implement prod deployment by promoting images from staging to prod.  Locks our deploy action to use the version containing chanzuckerberg/github-actions/pull/228, which enables a new argument needed for this feature.


[CZID-8804]: https://czi-tech.atlassian.net/browse/CZID-8804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Notes

* Set `IMAGE_SOURCE_ROLE_ARN` as Github secret in production environment
* `IMAGE_SOURCE_ENV` and `IMAGE_SOURCE_STACK` were previously set.