### PR TITLE
feat: Pass CSRF token when querying CZID Rails graphql

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -6,6 +6,7 @@ sources:
         source: ./sources/czid-schema.graphql
         operationHeaders:
           Cookie: "{context.headers['cookie']}"
+          "X-CSRF-Token": "{context.headers['x-csrf-token']}"
   - name: CZIDREST
     handler:
       jsonSchema:


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-8322]

## Description

Pass CSRF token to CZ ID Rails webapp graphQL endpoint when it is available as a header.  This increases protection against CSRF attacks when querying the CZ ID Rails webapp graphQL API

## Notes
* Related CZ ID PR: chanzuckerberg/czid-web-private/pull/4049
* In local dev, this was safe to deploy even if the React Relay client was not sending CSRF tokens in the header.  I will verify on sandbox as well, but this should be safe to deploy independently of CZ ID changes.

## Tests
* deployed this branch to `sandbox` env, and `main` branch of `czid-web` to `sandbox` env, and things still worked (so basically this PR is ok even if there is no X-CSRF header in the request).


[CZID-8322]: https://czi-tech.atlassian.net/browse/CZID-8322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ