### PR TITLE
feat: Add CSRF prevention plugin

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -6,7 +6,6 @@ sources:
         source: ./sources/czid-schema.graphql
         operationHeaders:
           Cookie: "{context.headers['cookie']}"
-          "X-CSRF-Token": "{context.headers['x-csrf-token']}"
   - name: CZIDREST
     handler:
       jsonSchema:

--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -142,6 +142,9 @@ additionalTypeDefs: |
   }
 additionalResolvers:
   - ./resolvers.ts
+plugins:
+  - csrfPrevention:
+      requestHeaders: ['x-graphql-yoga-csrf']
 serve:
   port: 4444
   endpoint: "/graphqlfed"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@graphql-mesh/cli": "^0.87.15",
         "@graphql-mesh/graphql": "^0.95.7",
         "@graphql-mesh/json-schema": "^0.95.10",
+        "@graphql-yoga/plugin-csrf-prevention": "^3.0.0",
         "graphql": "^16.8.1"
       }
     },
@@ -2139,6 +2140,17 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@graphql-yoga/plugin-csrf-prevention": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/plugin-csrf-prevention/-/plugin-csrf-prevention-3.0.0.tgz",
+      "integrity": "sha512-Wwgu8Uh0NJcsRhXWjEup1RAaPitdeyqDxbtacG1LXeFFAEvceR7kK/Mz5sgLjebZG6HtmdtsDeiDn/ENjejJjg==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "graphql-yoga": "^5.0.0"
       }
     },
     "node_modules/@graphql-yoga/plugin-persisted-operations": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@graphql-mesh/cli": "^0.87.15",
     "@graphql-mesh/graphql": "^0.95.7",
     "@graphql-mesh/json-schema": "^0.95.10",
+    "@graphql-yoga/plugin-csrf-prevention": "^3.0.0",
     "graphql": "^16.8.1"
   },
   "overrides": {}


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-8322]

## Description

Add CSRF protection to graphQL mesh using `@graphql-yoga/plugin-csrf-prevention`: https://the-guild.dev/graphql/mesh/docs/plugins/csrf. 

Remove CSRF token being passed as header, as this check is now disabled.

## Notes

### Dependencies
* [x] chanzuckerberg/czid-web-private/pull/4049
  * We need to wait until this PR is merged to that appropriate headers are being sent by the React app.
  * deployed in chanzuckerberg/czid-web-private/pull/4114
 
### Developer actions
1. Containers need to be rebuilt:
    ```
    docker compose down
    docker compose build
    docker compose up
    ```
2.  CSRF header need to be added to GraphiQL if you wish to use the playground:
    ```
    {
      "x-graphql-yoga-csrf": "csrf",
    }
    ````
![image](https://github.com/chanzuckerberg/czid-graphql-federation-server/assets/2072627/ed9d7264-7dbe-4d61-9a30-ac1454c9db58)

## Tests
Test that there are no regressions in functionality that uses Rails graphQL schema.  This includes the following:
* Pathogen list
* Quality control page
* User creation

- [x] tested locally (against `main` branch of CZ ID)
- [x] tested in sandbox (against `main` branch of CZ ID)

[CZID-8322]: https://czi-tech.atlassian.net/browse/CZID-8322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ