### PR TITLE
chore: swap sampleId type to ID to support QualityControlQuery

### DIFF
--- a/sources/czid-schema.graphql
+++ b/sources/czid-schema.graphql
@@ -208,7 +208,7 @@ type Query {
   pathogenList(version: String): PathogenList!
   project(id: Int!): Project!
   sample(sampleId: Int!): Sample!
-  sampleReadsStats(sampleIds: [Int!]!): SampleReadsStatsList!
+  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
   samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
   user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
 }
@@ -225,7 +225,7 @@ type Sample {
   editable: Boolean
   hostGenome: HostGenome
   hostGenomeId: Int
-  id: Int!
+  id: ID!
   initialWorkflow: String!
   maxInputFragments: Int
   name: String!
@@ -280,7 +280,7 @@ type SampleReadsStats {
   initialReads: Int
   name: String
   pipelineVersion: String
-  sampleId: Int!
+  sampleId: ID!
   steps: [SampleSteps!]
   wdlVersion: String
 }


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-8652]

## Description

Change graphql scheme to match changes in this [PR](https://github.com/chanzuckerberg/czid-web-private/pull/4052/)

## Notes
This is a non-breaking change. The federated `sampleReadsStats` query is not currently being used in the web-app.

Note that this change must be merged before the associated PR on the web-app side can be merged.

## Tests
Tested locally


[CZID-8652]: https://czi-tech.atlassian.net/browse/CZID-8652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ