### PR TITLE
feat!: swap sampleId type to ID to support QualityControlQuery

### DIFF
--- a/sources/czid-schema.graphql
+++ b/sources/czid-schema.graphql
@@ -208,7 +208,7 @@ type Query {
   pathogenList(version: String): PathogenList!
   project(id: Int!): Project!
   sample(sampleId: Int!): Sample!
-  sampleReadsStats(sampleIds: [Int!]!): SampleReadsStatsList!
+  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
   samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
   user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
 }
@@ -225,7 +225,7 @@ type Sample {
   editable: Boolean
   hostGenome: HostGenome
   hostGenomeId: Int
-  id: Int!
+  id: ID!
   initialWorkflow: String!
   maxInputFragments: Int
   name: String!
@@ -280,7 +280,7 @@ type SampleReadsStats {
   initialReads: Int
   name: String
   pipelineVersion: String
-  sampleId: Int!
+  sampleId: ID!
   steps: [SampleSteps!]
   wdlVersion: String
 }


### PR DESCRIPTION
Reverts chanzuckerberg/czid-graphql-federation-server#20

Re-releasing #16 as a breaking change.  As mentioned in #16, this will not break anything in CZ ID, because the graphQL mesh federated query is not currently in use, but changing types in a graphQL schema should generally be considered a breaking change, and we do want this to be explicitly included in a release.

