### PR TITLE
fix: updates to ConsensusGenomeWorkflowResults type

### DIFF
--- a/json-schemas/consensusGenomeWorkflowResults.json
+++ b/json-schemas/consensusGenomeWorkflowResults.json
@@ -48,7 +48,7 @@
                             "items": {
                                 "type": "array",
                                 "items": {
-                                    "type": "integer"
+                                    "type": "float"
                                 }
                             }
                         },
@@ -81,7 +81,7 @@
                     "type": "object",
                     "properties": {
                         "id": {
-                            "type": "integer"
+                            "type": "string"
                         },
                         "name": {
                             "type": "string"

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -54,7 +54,7 @@ export const resolvers: Resolvers = {
           accession_id: taxon_info.accession_id,
           accession_name: taxon_info.accession_name,
           taxon: {
-            id: taxon_info.taxon_id,
+            id: taxon_info.taxon_id.toString(),
             name: taxon_info.taxon_name,
           },
         },


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-8598] Convert ConsensusGenomeView and children to GQL

## Description

After testing the incoming responses to this endpoint in the web app, I found a few more type fixes. 

## Tests

### In IDE:

> query ConsensusGenomeViewQuery {
>     ConsensusGenomeWorkflowResults(workflowRunId: "27863"){
>       reference_genome {
>         accession_id
>         accession_name
>         taxon {
>           name
>          id
>       }
>     }
>     metric_consensus_genome {
>       mapped_reads
>       n_actg
>       n_ambiguous
>       n_missing
>       ref_snps
>       percent_identity
>       gc_percent
>       percent_genome_called
>       coverage_viz {
>         coverage
>         coverage_bin_size
>         coverage_breadth
>         coverage_depth
>         total_length
>       }
>     }
>   }
> } 
> 

- [ ] Should succeed without errors

### In Web App: 
- [ ] Go to https://staging.czid.org/samples/27863 and navigate to the Consensus Genome Tab
- [ ] Use the Dropdown to change in between CG workflow runs. Below are a couple of Screenshots of what to expect:

![Screenshot 2023-12-04 at 2 51 30 PM](https://github.com/chanzuckerberg/czid-graphql-federation-server/assets/13947999/ac8d4cbb-882d-4af8-8f08-c82b07ca655c)
![Screenshot 2023-12-04 at 2 51 39 PM](https://github.com/chanzuckerberg/czid-graphql-federation-server/assets/13947999/946b2e28-29e9-45e9-ad52-1b7ace5b0019)

