### PR TITLE
feat: restrict CORS origin for graphQL mesh

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -214,4 +214,4 @@ serve:
   endpoint: "/graphqlfed"
   playground: true
   cors:
-    origin: "${API_URL},${ADDITIONAL_CORS_ORIGINS}"
+    origin: "${ALLOWED_CORS_ORIGINS}"

--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -213,3 +213,5 @@ serve:
   port: 4444
   endpoint: "/graphqlfed"
   playground: true
+  cors:
+    origin: "${API_URL},${ADDITIONAL_CORS_ORIGINS}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     restart: always
     environment:
       API_URL: http://web:3001
+      ADDITIONAL_CORS_ORIGINS: http://localhost:3000
     ports:
       - "4444:4444"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     environment:
       API_URL: http://web:3001
-      ADDITIONAL_CORS_ORIGINS: http://localhost:3000
+      ALLOWED_CORS_ORIGINS: "http://web:3001,http://localhost:3000"
     ports:
       - "4444:4444"
     volumes:


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-8925]

## Description

Restrict the CORS Origins for graphQL mesh to address Armor Code security alert.  See JIRA ticket for details.

## Notes
* Must add new `ALLOWED_CORS_ORIGINS` env var for each environment
  * [x] sandbox: `https://sandbox.czid.org`
  * [x] staging: `https://staging.czid.org` 
  * [x] production: `https://czid.org`

## Tests

* Manually test that graphQL queries in playground and webapp work
  * [x] tested locally
  * [x] tested sandbox


[CZID-8925]: https://czi-tech.atlassian.net/browse/CZID-8925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ