### PR TITLE
fix: possible fix for Relay data updating

### DIFF
--- a/json-schemas/metadataItems.json
+++ b/json-schemas/metadataItems.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "properties":{
+  "id": {
+      "type": "string"
+  },
+  "key": {
+      "type": "string"
+  },
+  "raw_value": {
+      "type": "string"
+  },
+  "string_validated_value": {
+      "type": "string"
+  },
+  "number_validated_value": {
+      "type": "integer"
+  },
+  "sample_id": {
+      "type": "integer"
+  },
+  "created_at": {
+      "type": "string"
+  },
+  "updated_at": {
+      "type": "string"
+  },
+  "date_validated_value": {
+      "type": "string"
+  },
+  "metadata_field_id": {
+      "type": "integer"
+  },
+  "location_id": {
+      "type": "integer"
+  },
+  "base_type": {
+      "type": "string"
+  }
+
+}
+}

--- a/json-schemas/sampleMetadata.json
+++ b/json-schemas/sampleMetadata.json
@@ -3,47 +3,7 @@
     "properties": {
         "metadata": {
             "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "key": {
-                        "type": "string"
-                    },
-                    "raw_value": {
-                        "type": "string"
-                    },
-                    "string_validated_value": {
-                        "type": "string"
-                    },
-                    "number_validated_value": {
-                        "type": "string"
-                    },
-                    "sample_id": {
-                        "type": "integer"
-                    },
-                    "created_at": {
-                        "type": "string"
-                    },
-                    "updated_at": {
-                        "type": "string"
-                    },
-                    "date_validated_value": {
-                        "type": "string"
-                    },
-                    "metadata_field_id": {
-                        "type": "integer"
-                    },
-                    "location_id": {
-                        "type": "integer"
-                    },
-                    "base_type": {
-                        "type": "string"
-                    }
-                }
-            }
+            "items": { "$ref": "./metadataItems.json" }
         },
         "additional_info": {
             "type": "object",

--- a/json-schemas/updateMetadataResponse.json
+++ b/json-schemas/updateMetadataResponse.json
@@ -6,6 +6,51 @@
         },
         "message": {
             "type": "string"
+        },
+        "metadata": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties":{
+                "id": {
+                    "type": "integer"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "raw_value": {
+                    "type": "string"
+                },
+                "string_validated_value": {
+                    "type": "string"
+                },
+                "number_validated_value": {
+                    "type": "integer"
+                },
+                "sample_id": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "date_validated_value": {
+                    "type": "string"
+                },
+                "metadata_field_id": {
+                    "type": "integer"
+                },
+                "location_id": {
+                    "type": "integer"
+                },
+                "base_type": {
+                    "type": "string"
+                }
+            
+            }
         }
     }
+}
 }

--- a/json-schemas/updateMetadataResponse.json
+++ b/json-schemas/updateMetadataResponse.json
@@ -13,7 +13,7 @@
                 "type": "object",
                 "properties":{
                 "id": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "key": {
                     "type": "string"

--- a/json-schemas/updateMetadataResponse.json
+++ b/json-schemas/updateMetadataResponse.json
@@ -9,48 +9,7 @@
         },
         "metadata": {
             "type": "array",
-            "items": {
-                "type": "object",
-                "properties":{
-                "id": {
-                    "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "raw_value": {
-                    "type": "string"
-                },
-                "string_validated_value": {
-                    "type": "string"
-                },
-                "number_validated_value": {
-                    "type": "integer"
-                },
-                "sample_id": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "date_validated_value": {
-                    "type": "string"
-                },
-                "metadata_field_id": {
-                    "type": "integer"
-                },
-                "location_id": {
-                    "type": "integer"
-                },
-                "base_type": {
-                    "type": "string"
-                }
-            
-            }
-        }
+            "items": { "$ref": "./metadataItems.json" }
     }
 }
 }

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -402,7 +402,7 @@ export const resolvers: Resolvers = {
         const metadata = res2.metadata.filter((item) => {
           return item.key === body.field;
         }).map((item) => {
-          item.id = item.id.toString() + item.key;
+          item.id = item.id.toString();
           return item;
         });
         console.log(metadata)

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -383,13 +383,32 @@ export const resolvers: Resolvers = {
         field: args?.input?.field,
         value: args?.input?.value,
       };
-      const res = await postWithCSRF(
+      const res1 = await postWithCSRF(
         `/samples/${args.sampleId}/save_metadata_v2`,
         body,
         args,
         context
       );
-      return res;
+      console.log(res1.status);
+      if (res1.status === "success") {
+        const res2 = await get(
+          `/samples/${args.sampleId}/metadata`,
+          args,
+          context
+        );
+      // in res2, the metadata is an array of objects
+      // find the object with the field that matches the field in the input
+      // then return the value of that object
+        const metadata = res2.metadata.filter((item) => {
+          return item.key === body.field;
+        });
+        console.log(metadata)
+      return {
+        status: res1.status,
+        message: res1.message,
+        metadata: metadata,
+      };
+    }
     },
     UpdateSampleNotes: async (root, args, context, info) => {
       const body = {

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -401,6 +401,9 @@ export const resolvers: Resolvers = {
       // then return the value of that object
         const metadata = res2.metadata.filter((item) => {
           return item.key === body.field;
+        }).map((item) => {
+          item.id = item.id.toString() + item.key;
+          return item;
         });
         console.log(metadata)
       return {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-XXXX]

## Description

This PR adds a second REST call within the UpdateMetadata mutation to get the full data of the updated metadata specifically so we can return the `id` to Relay and it can potentially figure out how to update the store natively.

## Notes

This PR is a WIP. 

## Tests

Tested with 
```
mutation UpdateMetadataMutation{
  UpdateMetadata(
    sampleId: "26974"
    input:{
      field:"collection_date"
      value:"2020-07"
      authenticityToken:"G7v33KvfPm7nPqn50K0zP0krLoPSuIjzEr5DhtQSW3NFA0pxjkTY0k71ReYF6klGxHXljM5tvGaGD4YBgtkKbQ=="
    }
  ){
    message
    status
    metadata{
      id
    }
  }
}
```

which returns: 
```
{
  "data": {
    "UpdateMetadata": {
      "message": "Saved successfully",
      "status": "success",
      "metadata": [
        {
          "id": 76163
        }
      ]
    }
  }
}
```
