### PR TITLE
fix: Change ercc_comparison type from integer to float

### DIFF
--- a/json-schemas/sampleMetadata.json
+++ b/json-schemas/sampleMetadata.json
@@ -84,7 +84,7 @@
                                 "type": "integer"
                             },
                             "expected": {
-                                "type": "integer"
+                                "type": "float"
                             }
                         }
                     }


### PR DESCRIPTION
# Pull Request
 
JIRA Ticket - no ticket

## Description

Changing the `ercc_comparison.expected` type from integer to float will all the correct value to come through the mesh server rather than null. This is to unblock [CZID-8606](https://czi-tech.atlassian.net/browse/CZID-8606)


## Tests

The following query should **not** return `null` as an `expected` value.
```
query MyQuery {
  SampleMetadata(sampleId: "26940") {
    additional_info {
      ercc_comparison {
        actual
        expected
        name
      }
    }
  }
}
```


[CZID-8606]: https://czi-tech.atlassian.net/browse/CZID-8606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ