### PR TITLE
fix: adding multiple location types and Update metadata values

### DIFF
--- a/json-schemas/locationV2.json
+++ b/json-schemas/locationV2.json
@@ -29,13 +29,13 @@
             "type": "integer"
         },
         "locationiq_id": {
-            "type": "integer"
+            "type": "float"
         },
         "lat": {
-            "type": "string"
+            "type": "float"
         },
         "lng": {
-            "type": "string"
+            "type": "float"
         },
         "created_at": {
             "type": "string"
@@ -56,6 +56,18 @@
             "type": "integer"
         },
         "city_id": {
+            "type": "string"
+        },
+        "raw_value": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "key": {
             "type": "string"
         }
     }

--- a/json-schemas/locationV2.json
+++ b/json-schemas/locationV2.json
@@ -1,0 +1,62 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "name": {
+            "type": "string"
+        },
+        "geo_level": {
+            "type": "string"
+        },
+        "country_name": {
+            "type": "string"
+        },
+        "country_code": {
+            "type": "string"
+        },
+        "state_name": {
+            "type": "string"
+        },
+        "subdivision_name": {
+            "type": "string"
+        },
+        "city_name": {
+            "type": "string"
+        },
+        "osm_id": {
+            "type": "integer"
+        },
+        "locationiq_id": {
+            "type": "integer"
+        },
+        "lat": {
+            "type": "string"
+        },
+        "lng": {
+            "type": "string"
+        },
+        "created_at": {
+            "type": "string"
+        },
+        "updated_at": {
+            "type": "string"
+        },
+        "osm_type": {
+            "type": "string"
+        },
+        "country_id": {
+            "type": "integer"
+        },
+        "state_id": {
+            "type": "integer"
+        },
+        "subdivision_id": {
+            "type": "integer"
+        },
+        "city_id": {
+            "type": "string"
+        }
+    }
+}

--- a/json-schemas/sampleMetadata.json
+++ b/json-schemas/sampleMetadata.json
@@ -36,60 +36,10 @@
                     "location_validated_value": {
                          "oneOf": [
                             {
-                             "type": "string"
+                                "type": "string"
                             },
                             {
-                              "type": "object",
-                              "properties": {
-                                "lat": {
-                                  "type": "number"
-                                },
-                                "lng": {
-                                  "type": "number"
-                                },
-                                "city_name": {
-                                  "type": "string"
-                                },
-                                "state_name": {
-                                  "type": "string"
-                                },
-                                "country_name": {
-                                  "type": "string"
-                                },
-                                "country_code": {
-                                  "type": "string"
-                                },
-                                "description": {
-                                  "type": "string"
-                                },
-                                "geo_level": {
-                                  "type": "string"
-                                },
-                                "key": {
-                                  "type": "string"
-                                },
-                                "locationiq_id": {
-                                  "type": "integer"
-                                },
-                                "name": {
-                                  "type": "string"
-                                },
-                                "osm_id": {
-                                  "type": "integer"
-                                },
-                                "osm_type": {
-                                  "type": "string"
-                                },
-                                "refetch_adjusted_location": {
-                                  "type": "boolean"
-                                },
-                                "subdivision_name": {
-                                  "type": "string"
-                                },
-                                "title": {
-                                  "type": "string"
-                                }
-                              }
+                                "$ref": "./locationV2.json"
                             }
                           ]
                     },

--- a/json-schemas/sampleMetadata.json
+++ b/json-schemas/sampleMetadata.json
@@ -36,7 +36,12 @@
                     "location_validated_value": {
                          "oneOf": [
                             {
-                                "type": "string"
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
                             },
                             {
                                 "$ref": "./locationV2.json"

--- a/json-schemas/sampleMetadata.json
+++ b/json-schemas/sampleMetadata.json
@@ -33,6 +33,66 @@
                     "date_validated_value": {
                         "type": "string"
                     },
+                    "location_validated_value": {
+                         "oneOf": [
+                            {
+                             "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "number"
+                                },
+                                "lng": {
+                                  "type": "number"
+                                },
+                                "city_name": {
+                                  "type": "string"
+                                },
+                                "state_name": {
+                                  "type": "string"
+                                },
+                                "country_name": {
+                                  "type": "string"
+                                },
+                                "country_code": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "geo_level": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "locationiq_id": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "osm_id": {
+                                  "type": "integer"
+                                },
+                                "osm_type": {
+                                  "type": "string"
+                                },
+                                "refetch_adjusted_location": {
+                                  "type": "boolean"
+                                },
+                                "subdivision_name": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
+                    },
                     "metadata_field_id": {
                         "type": "integer"
                     },

--- a/json-schemas/updateMetadata.json
+++ b/json-schemas/updateMetadata.json
@@ -5,7 +5,14 @@
             "type": "string"
         },
         "value": {
-            "type": "string"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "./locationV2.json"
+                }
+            ]
         },
         "authenticityToken": {
             "type": "string"

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -101,8 +101,8 @@ export const resolvers: Resolvers = {
           };
         } else if ( typeof field.location_validated_value === "string" ){
           field.location_validated_value = {
-            __typename: "String_container", 
-            String: field.location_validated_value
+            __typename: "query_SampleMetadata_metadata_items_location_validated_value_oneOf_0", 
+            name: field.location_validated_value
           };
         } else {
           field.location_validated_value = null;

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -398,7 +398,7 @@ export const resolvers: Resolvers = {
     UpdateMetadata: async (root, args, context, info) => {
       const body = {
         field: args?.input?.field,
-        value: args?.input?.value,
+        value: args?.input?.value.String ? args.input.value.String : args?.input?.value.query_SampleMetadata_metadata_items_location_validated_value_oneOf_1_Input,
       };
       const res = await postWithCSRF(
         `/samples/${args.sampleId}/save_metadata_v2`,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -83,6 +83,7 @@ export const resolvers: Resolvers = {
         args,
         context
       );
+      console.log(res);
       try {
         const metadata = res.metadata.map((item) => {
           item.id = item.id.toString();
@@ -92,6 +93,7 @@ export const resolvers: Resolvers = {
           res.additional_info.pipeline_run.id = res.additional_info.pipeline_run.id.toString();
         }
         res.metadata = metadata;
+        console.log(res);
         return res;
       } catch {
         return res;

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -83,7 +83,6 @@ export const resolvers: Resolvers = {
         args,
         context
       );
-      console.log(res);
       try {
         const metadata = res.metadata.map((item) => {
           item.id = item.id.toString();
@@ -92,8 +91,24 @@ export const resolvers: Resolvers = {
         if (res?.additional_info?.pipeline_run?.id){
           res.additional_info.pipeline_run.id = res.additional_info.pipeline_run.id.toString();
         }
+        // location_validated_value is a union type, so we need to add __typename to the object
+        metadata.map((field) => {
+          if( typeof field.location_validated_value === "object" ) {
+          field.location_validated_value = {
+            __typename: "query_SampleMetadata_metadata_items_location_validated_value_oneOf_1", 
+            ...field.location_validated_value,
+            id: field.location_validated_value.id.toString(),
+          };
+        } else if ( typeof field.location_validated_value === "string" ){
+          field.location_validated_value = {
+            __typename: "String_container", 
+            String: field.location_validated_value
+          };
+        } else {
+          field.location_validated_value = null;
+        }
+      });
         res.metadata = metadata;
-        console.log(res);
         return res;
       } catch {
         return res;

--- a/sample-responses/locationV2.json
+++ b/sample-responses/locationV2.json
@@ -1,0 +1,21 @@
+{ 
+  "id": 5280, 
+  "name": "Río Mula, Region of Murcia, Spain", 
+  "geo_level": "subdivision", 
+  "country_name": "Spain", 
+  "country_code": "es", 
+  "state_name": "Region of Murcia", 
+  "subdivision_name": "Río Mula", 
+  "city_name": "", 
+  "osm_id": 2902369, 
+  "locationiq_id": 330187145, 
+  "lat": "38.03", 
+  "lng": "-1.48", 
+  "created_at": "2024-01-04T12:57:24.000-08:00", 
+  "updated_at": "2024-01-04T12:57:25.000-08:00", 
+  "osm_type": "relation", 
+  "country_id": 3679, 
+  "state_id": 5281, 
+  "subdivision_id": 5280, 
+  "city_id": null 
+}


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9028](https://czi-tech.atlassian.net/browse/CZID-9028)

## Description

The `location_validated_value` needed to be added to the metadata items but also it needed to account for the fact that sometimes it will return a string and sometimes a location object. This required using a Union type and adjusting the resolver to tell GraphQL what the returned type was using the `__typename` field.

We also had to change the UpdateMetadata query to accept Location Objects as well as strings as their value.

## Tests

Try to test on a Sample with a string location value and an object location value:


```query MyQuery {
  SampleMetadata(sampleId: "24142") {
    metadata {
      raw_value
      location_validated_value {
        ... on query_SampleMetadata_metadata_items_location_validated_value_oneOf_0 {
          name
        }
        ... on query_SampleMetadata_metadata_items_location_validated_value_oneOf_1 {
          name
          id
        }
      }
    }
  }
}

mutation MyMutation {
  UpdateMetadata(
    sampleId: "26981"
    input: {
      field: "collection_location_v2", 
      authenticityToken: "eSOvx60Sbu/LprmrvcesUIca+jB1yhbinSBNWQoZ5rUnmxJqiImIU2JtVbRogNYpCkQxP2kfIncJkYjeXNK3qw==", 
      value: {
        query_SampleMetadata_metadata_items_location_validated_value_oneOf_1_Input: {
  		name: "Pickle Lake, Canada",
                geo_level: "country",
                country_name: "Canada",
                state_name: "",
                subdivision_name: "",
                city_name: "",
                lat: 51.46,
                lng: -90.23,
                country_code: "ca",
                osm_id: 11021994,
                osm_type: "relation",
                locationiq_id: 320441851107,
                title: "Pickle Lake",
                description: "Canada",
                key: "loc-320441851107"
        }
      }
    }
  ) {
    message
    status
  }
}


[CZID-9028]: https://czi-tech.atlassian.net/browse/CZID-9028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ