### PR TITLE
feat(ci): Align release process to CZ ID manual release cadence

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,48 +15,75 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Get latest or specified release
+        uses: actions/github-script@v7
+        id: get-release
+        with:
+          retries: 3
+          script: |
+            if (${{ github.event.inputs.release_tag != '' }}) {
+              return github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: "${{ github.event.inputs.release_tag }}"
+              })
+            } else {
+              return github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              })
+            }
+      - name: Output Github Release
+        if: steps.get-release.outputs.result != ''
+        id: set-release-tag
+        run: |
+          parsed_tag_name=$(echo '${{ steps.get-release.outputs.result }}' | jq -r '.data.tag_name')
+          echo "Tag name is: $parsed_tag_name"
+          echo "release_tag=$parsed_tag_name\n" >> $GITHUB_OUTPUT
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Assume happy-api deployment role
-        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 1200
-          role-session-name: CzidGraphQLFederationUpdateProd
-      - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@main
-      - name: Set git SHA
-        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
-        with:
-          app_config_name: CZID_GQL_FED_GIT_SHA
-          app_config_value: ${{ github.sha }}
-          happy_env: prod
-      - name: Set release version
-        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
-        with:
-          app_config_name: CZID_GQL_FED_GIT_VERSION
-          app_config_value: ${{ github.event.release.tag_name }}
-          happy_env: prod
-      - name: Set CZ ID Rails API URL
-        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
-        with:
-          app_config_name: API_URL
-          app_config_value: ${{ vars.API_URL}}
-          happy_env: prod
-      - name: Set allowed CORS origins
-        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
-        with:
-          app_config_name: ALLOWED_CORS_ORIGINS
-          app_config_value: ${{ vars.ALLOWED_CORS_ORIGINS}}
-          happy_env: prod
-      - name: Deploy to production env
-        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.26.0
-        with:
-          tfe-token: ${{ secrets.TFE_TOKEN }}
-          env: ${{ vars.HAPPY_ENV }}
-          image-source-env: ${{ vars.IMAGE_SOURCE_ENV }}
-          image-source-stack: ${{ secrets.IMAGE_SOURCE_STACK }}
-          image-source-role-arn: ${{ secrets.IMAGE_SOURCE_ROLE_ARN }}
-          stack-name: ${{ secrets.HAPPY_STACK_NAME }}
-          version-lock-file: .happy/version.lock
+          ref: ${{ steps.get-release.outputs.result }}
+      # - name: Assume happy-api deployment role
+      #   uses: aws-actions/configure-aws-credentials@v2
+      #   with:
+      #     aws-region: us-west-2
+      #     role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      #     role-duration-seconds: 1200
+      #     role-session-name: CzidGraphQLFederationUpdateProd
+      # - name: Install happy
+      #   uses: chanzuckerberg/github-actions/.github/actions/install-happy@main
+      # - name: Set git SHA
+      #   uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
+      #   with:
+      #     app_config_name: CZID_GQL_FED_GIT_SHA
+      #     app_config_value: ${{ github.sha }}
+      #     happy_env: prod
+      # - name: Set release version
+      #   uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
+      #   with:
+      #     app_config_name: CZID_GQL_FED_GIT_VERSION
+      #     app_config_value: ${{ github.event.release.tag_name || }}
+      #     happy_env: prod
+      # - name: Set CZ ID Rails API URL
+      #   uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
+      #   with:
+      #     app_config_name: API_URL
+      #     app_config_value: ${{ vars.API_URL}}
+      #     happy_env: prod
+      # - name: Set allowed CORS origins
+      #   uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
+      #   with:
+      #     app_config_name: ALLOWED_CORS_ORIGINS
+      #     app_config_value: ${{ vars.ALLOWED_CORS_ORIGINS}}
+      #     happy_env: prod
+      # - name: Deploy to production env
+      #   uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.26.0
+      #   with:
+      #     tfe-token: ${{ secrets.TFE_TOKEN }}
+      #     env: ${{ vars.HAPPY_ENV }}
+      #     image-source-env: ${{ vars.IMAGE_SOURCE_ENV }}
+      #     image-source-stack: ${{ secrets.IMAGE_SOURCE_STACK }}
+      #     image-source-role-arn: ${{ secrets.IMAGE_SOURCE_ROLE_ARN }}
+      #     stack-name: ${{ secrets.HAPPY_STACK_NAME }}
+      #     version-lock-file: .happy/version.lock

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.get-release.outputs.result }}
+          ref: ${{ steps.set-release-tag.outputs.release_tag }}
       # - name: Assume happy-api deployment role
       #   uses: aws-actions/configure-aws-credentials@v2
       #   with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,6 +1,10 @@
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag version to deploy to production'
+        required: false
+        type: string
 
 name: Deploy release to prod
 jobs:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,7 +1,6 @@
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 name: Deploy main to staging
 jobs:


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9222]

## Description
These are the first steps in updating the release cadence for this service.
* Turn off automatic staging deploys (on PR merge)
* Test github action script to get the latest or a specified release tag

## Notes
Eventually, if we want to move back to a on-demand or continuous release cadence, we'll likely need to undo most of this PR.  To make sure this doesn't get lost, the original commit to stop automatic staging deploys is here: https://github.com/chanzuckerberg/czid-graphql-federation-server/pull/67/commits/0d22c3cb0d5f59503006b4a713d5b40bfc6ab242

### Deploying specific branch

This is mostly a reminder, but the `deploy-happy-stack` checks out the repo on its own.  This is an important distinction because whatever `ref` that is checked out by a github action is not used by the `deploy-happy-stack` action.  Instead, if you want to pass in a ref besides what the github action has an an input, you need to pass it using [the `github-repo-branch` options](https://github.com/chanzuckerberg/github-actions/blob/a63ad0e12357e3af246433d8a26a1fef1d95fc44/.github/actions/deploy-happy-stack/action.yml#L64-L66) 

## Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*


[CZID-9222]: https://czi-tech.atlassian.net/browse/CZID-9222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ