### PR TITLE
feat: allow manual staging deploy, re-enable prod deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -72,8 +72,6 @@ jobs:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: ${{ vars.HAPPY_ENV }}
           github-repo-branch: ${{ needs.get-release-tag.outputs.release_tag }}
-          image-source-env: ${{ vars.IMAGE_SOURCE_ENV }}
-          image-source-stack: ${{ secrets.IMAGE_SOURCE_STACK }}
-          image-source-role-arn: ${{ secrets.IMAGE_SOURCE_ROLE_ARN }}
+          create-tag: true
           stack-name: ${{ secrets.HAPPY_STACK_NAME }}
           version-lock-file: .happy/version.lock

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -33,46 +33,47 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: '${{ needs.get-release-tag.outputs.release_tag }}'
-      # - name: Assume happy-api deployment role
-      #   uses: aws-actions/configure-aws-credentials@v2
-      #   with:
-      #     aws-region: us-west-2
-      #     role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-      #     role-duration-seconds: 1200
-      #     role-session-name: CzidGraphQLFederationUpdateProd
-      # - name: Install happy
-      #   uses: chanzuckerberg/github-actions/.github/actions/install-happy@main
-      # - name: Set git SHA
-      #   uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
-      #   with:
-      #     app_config_name: CZID_GQL_FED_GIT_SHA
-      #     app_config_value: ${{ github.sha }}
-      #     happy_env: prod
-      # - name: Set release version
-      #   uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
-      #   with:
-      #     app_config_name: CZID_GQL_FED_GIT_VERSION
-      #     app_config_value: ${{ github.event.release.tag_name || }}
-      #     happy_env: prod
-      # - name: Set CZ ID Rails API URL
-      #   uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
-      #   with:
-      #     app_config_name: API_URL
-      #     app_config_value: ${{ vars.API_URL}}
-      #     happy_env: prod
-      # - name: Set allowed CORS origins
-      #   uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
-      #   with:
-      #     app_config_name: ALLOWED_CORS_ORIGINS
-      #     app_config_value: ${{ vars.ALLOWED_CORS_ORIGINS}}
-      #     happy_env: prod
-      # - name: Deploy to production env
-      #   uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.26.0
-      #   with:
-      #     tfe-token: ${{ secrets.TFE_TOKEN }}
-      #     env: ${{ vars.HAPPY_ENV }}
-      #     image-source-env: ${{ vars.IMAGE_SOURCE_ENV }}
-      #     image-source-stack: ${{ secrets.IMAGE_SOURCE_STACK }}
-      #     image-source-role-arn: ${{ secrets.IMAGE_SOURCE_ROLE_ARN }}
-      #     stack-name: ${{ secrets.HAPPY_STACK_NAME }}
-      #     version-lock-file: .happy/version.lock
+      - name: Assume happy-api deployment role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1200
+          role-session-name: CzidGraphQLFederationUpdateProd
+      - name: Install happy
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@main
+      - name: Set git SHA
+        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
+        with:
+          app_config_name: CZID_GQL_FED_GIT_SHA
+          app_config_value: ${{ github.sha }}
+          happy_env: prod
+      - name: Set release version
+        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
+        with:
+          app_config_name: CZID_GQL_FED_GIT_VERSION
+          app_config_value: ${{ needs.get-release-tag.outputs.release_tag || ''}}
+          happy_env: prod
+      - name: Set CZ ID Rails API URL
+        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
+        with:
+          app_config_name: API_URL
+          app_config_value: ${{ vars.API_URL}}
+          happy_env: prod
+      - name: Set allowed CORS origins
+        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
+        with:
+          app_config_name: ALLOWED_CORS_ORIGINS
+          app_config_value: ${{ vars.ALLOWED_CORS_ORIGINS}}
+          happy_env: prod
+      - name: Deploy to production env
+        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.26.0
+        with:
+          tfe-token: ${{ secrets.TFE_TOKEN }}
+          env: ${{ vars.HAPPY_ENV }}
+          github-repo-branch: ${{ needs.get-release-tag.outputs.release_tag }}
+          image-source-env: ${{ vars.IMAGE_SOURCE_ENV }}
+          image-source-stack: ${{ secrets.IMAGE_SOURCE_STACK }}
+          image-source-role-arn: ${{ secrets.IMAGE_SOURCE_ROLE_ARN }}
+          stack-name: ${{ secrets.HAPPY_STACK_NAME }}
+          version-lock-file: .happy/version.lock

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,10 +1,30 @@
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag version to deploy to staging (defaults to latest)'
+        required: false
+        type: string
 
-name: Deploy main to staging
+name: Deploy release to staging
 jobs:
+  get-release-tag:
+    runs-on: [ARM64, self-hosted, Linux]
+    environment: staging
+    outputs:
+      release_tag: ${{ steps.get-release.outputs.release_tag}}
+    steps:
+      - name: Get latest or specified release
+        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/get-release-tag@main
+        id: get-release
+        with:
+          requested_release_tag: ${{ github.event.inputs.release_tag || '' }}
+
   deploy-to-staging-env:
+    needs: get-release-tag
+    if: needs.get-release-tag.outputs.release_tag != ''
     runs-on: [ARM64, self-hosted, Linux]
     environment: staging
     permissions:
@@ -13,6 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: '${{ needs.get-release-tag.outputs.release_tag }}'
       - name: Assume happy-api deployment role
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -22,11 +44,17 @@ jobs:
           role-session-name: CzidGraphQLFederationUpdateStaging
       - name: Install happy
         uses: chanzuckerberg/github-actions/.github/actions/install-happy@main
-      - name: Set version info
+      - name: Set git SHA
         uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
         with:
           app_config_name: CZID_GQL_FED_GIT_SHA
           app_config_value: ${{ github.sha }}
+          happy_env: staging
+      - name: Set release version
+        uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
+        with:
+          app_config_name: CZID_GQL_FED_GIT_VERSION
+          app_config_value: ${{ needs.get-release-tag.outputs.release_tag || ''}}
           happy_env: staging
       - name: Set CZ ID Rails API URL
         uses: chanzuckerberg/czid-graphql-federation-server/.github/actions/happy-config-set@main
@@ -45,6 +73,7 @@ jobs:
         with:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: ${{ vars.HAPPY_ENV }}
+          github-repo-branch: ${{ needs.get-release-tag.outputs.release_tag }}
           create-tag: true
           stack-name: ${{ secrets.HAPPY_STACK_NAME }}
           version-lock-file: .happy/version.lock

--- a/README.md
+++ b/README.md
@@ -65,13 +65,30 @@ There are two ways to [trigger a deploy to the sandbox environment](https://gith
 
 ### Staging deployment
 
-When there is a push to the `main` branch, the [`deploy-staging` workflow](https://github.com/chanzuckerberg/czid-graphql-federation-server/actions/workflows/deploy-staging.yml) pushes the `main` branch onto the `staging` branch, and deploys to the staging environment
+Merging a release-please release PR creates a new release, which triggers the [`deploy-staging` workflow](https://github.com/chanzuckerberg/czid-graphql-federation-server/actions/workflows/deploy-staging.yml).  This Github workflow deploys the newly created release tag to the staging environment.
+
+This workflow can also be manually triggered on [the actions page](https://github.com/chanzuckerberg/czid-graphql-federation-server/actions/workflows/deploy-staging.yml), with a optional release version tag.
 
 ### Production deployment
 
-When there is a push to the `main` branch (generally via PR merge), a release PR is created by the Release Please action.  The `release-please` bot keeps the release up to date as long as new commits comply with conventional commits (which is a required PR check).  So the release is always up to date with staging.
+Production releases are triggered by [manually running the deploy-prod workflow](https://github.com/chanzuckerberg/czid-graphql-federation-server/actions/workflows/deploy-prod.yml).  The workflow accepts a optional release version tag to deploy, but is set up to deploy the newer release version tag by default.
 
-When the PR is merged, Release Please will publish a Github release, which triggers a prod deployment.  During prod deployment, the image built in staging is promoted to the prod environment, with env vars updated.
+During prod deployment, the image built in staging is promoted to the prod environment, with env vars updated.
+
+### Release / Hot fix
+
+Since the staging and production deploys workflows can be triggered manually with a release tag, the workflows can be used to perform release / hot fixes.
+
+Before doing a release / hot fix, it is strongly recommended to perform a rollback to the last good version, if that can be done safely (i.e. no downstream dependencies).
+
+To perform a release / hot fix, perform the following steps
+
+1. Create and merge a pull request with the fix to the `main` branch.
+2. Check out the staging (for release fix) or production (for hot fix) release tag.
+3. Cherry-pick the fix PR commit to `main` onto the release tag.
+4. Bump the patch version of the release tag and create a tag.
+5. Deploy the new tag onto staging (release fix) and/or production.
+6. If this was a hotfix, you will also need to repeat the process to update the staging release version with the fix.
 
 ## TODO
 


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9222]

## Description
- Add manual workflow option for staging deploy, and use composite action to get release tag for staging
- Re-enable prod deploy
- Specify github branch (tag) for both staging and prod deploy
- Update docs

## Tests
Will be running deploys using the updated scripts in line with the CZ ID release cadence.


[CZID-9222]: https://czi-tech.atlassian.net/browse/CZID-9222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ