### PR TITLE
feat: Federate sequencingReads and consensusGenomes

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -125,6 +125,10 @@ sources:
             responseSchema: ./json-schemas/samplesResponse.json
             responseTypeName: samples
           - type: Query
+            field: sequencingReads
+            method: GET
+            path: /workflow_runs.json
+          - type: Query
             field: Taxons
             path: /pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false
             method: GET

--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -54,6 +54,13 @@ sources:
             responseSchema: ./json-schemas/cgOverview.json
             responseTypeName: ConsensusGenomeOverviewRows
           - type: Query
+            field: consensusGenomes
+            method: GET
+            path: /workflow_runs.json
+            requestSchema: ./json-schemas/consensusGenomesRequest.json
+            responseSchema: ./json-schemas/consensusGenomesResponse.json
+            responseTypeName: consensusGenomes
+          - type: Query
             field: ConsensusGenomeWorkflowResults
             path: /workflow_runs/{args.workflowRunId}/results
             method: GET
@@ -128,6 +135,9 @@ sources:
             field: sequencingReads
             method: GET
             path: /workflow_runs.json
+            requestSchema: ./json-schemas/sequencingReadsRequest.json
+            responseSchema: ./json-schemas/sequencingReadsResponse.json
+            responseTypeName: sequencingReads
           - type: Query
             field: Taxons
             path: /pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false

--- a/example-queries/consensus-genomes-query.graphql
+++ b/example-queries/consensus-genomes-query.graphql
@@ -1,4 +1,4 @@
-query TestQuery($unused: String) {
+query TestQuery {
     consensusGenomes(input: {
         where: {
             producingRunId: {

--- a/example-queries/consensus-genomes-query.graphql
+++ b/example-queries/consensus-genomes-query.graphql
@@ -1,0 +1,29 @@
+query TestQuery($unused: String) {
+    consensusGenomes(input: {
+    where: {
+        producingRunId: {
+        _in: ["abc", "def"]
+        }
+    }
+    todoRemove: {
+        search: "abc"
+    }
+    }) {
+    producingRunId
+    taxon {
+        name
+    }
+    sequencingRead {
+        sample {
+        metadatas {
+            edges {
+            node {
+                fieldName
+                value
+            }
+            }
+        }
+        }
+    }
+    }
+}

--- a/example-queries/consensus-genomes-query.graphql
+++ b/example-queries/consensus-genomes-query.graphql
@@ -1,29 +1,29 @@
 query TestQuery($unused: String) {
     consensusGenomes(input: {
-    where: {
-        producingRunId: {
-        _in: ["abc", "def"]
+        where: {
+            producingRunId: {
+            _in: ["abc", "def"]
+            }
         }
-    }
-    todoRemove: {
-        search: "abc"
-    }
+        todoRemove: {
+            search: "abc"
+        }
     }) {
-    producingRunId
-    taxon {
-        name
-    }
-    sequencingRead {
-        sample {
-        metadatas {
-            edges {
-            node {
-                fieldName
-                value
-            }
+        producingRunId
+        taxon {
+            name
+        }
+        sequencingRead {
+            sample {
+                metadatas {
+                    edges {
+                        node {
+                            fieldName
+                            value
+                        }
+                    }
+                }
             }
         }
-        }
-    }
     }
 }

--- a/example-queries/samples-query.graphql
+++ b/example-queries/samples-query.graphql
@@ -1,4 +1,4 @@
-query TestQuery($unused: String) {
+query TestQuery {
     samples(input: {
         where: {
             name: {

--- a/example-queries/samples-query.graphql
+++ b/example-queries/samples-query.graphql
@@ -1,0 +1,11 @@
+query TestQuery($unused: String) {
+    samples(input: {
+        where: {
+            name: {
+            _like: "abc",
+            }
+        },
+    }) {
+        id
+    }
+}

--- a/example-queries/samples-query.graphql
+++ b/example-queries/samples-query.graphql
@@ -4,7 +4,7 @@ query TestQuery($unused: String) {
             name: {
             _like: "abc",
             }
-        },
+        }
     }) {
         id
     }

--- a/example-queries/sequencing-reads-query.graphql
+++ b/example-queries/sequencing-reads-query.graphql
@@ -1,13 +1,13 @@
 query TestQuery($unused: String) {
     sequencingReads(input: {
-    where: {
-        id: {
-        _in: ["abc", "def"]
+        where: {
+            id: {
+            _in: ["abc", "def"]
+            }
         }
-    }
-    todoRemove: {
-        search: "abc"
-    }
+        todoRemove: {
+            search: "abc"
+        }
     }) {
     id
     sample {

--- a/example-queries/sequencing-reads-query.graphql
+++ b/example-queries/sequencing-reads-query.graphql
@@ -1,4 +1,4 @@
-query TestQuery($unused: String) {
+query TestQuery {
     sequencingReads(input: {
         where: {
             id: {

--- a/example-queries/sequencing-reads-query.graphql
+++ b/example-queries/sequencing-reads-query.graphql
@@ -1,0 +1,33 @@
+query TestQuery($unused: String) {
+    sequencingReads(input: {
+    where: {
+        id: {
+        _in: ["abc", "def"]
+        }
+    }
+    todoRemove: {
+        search: "abc"
+    }
+    }) {
+    id
+    sample {
+        metadatas {
+        edges {
+            node {
+            fieldName
+            value
+            }
+        }
+        }
+    }
+    consensusGenomes {
+        edges {
+        node {
+            taxon {
+            name
+            }
+        }
+        }
+    }
+    }
+}

--- a/example-queries/workflow-runs-query-empty.graphql
+++ b/example-queries/workflow-runs-query-empty.graphql
@@ -1,4 +1,4 @@
-query WorkflowRunsQuery($unused: String) {
+query WorkflowRunsQuery {
     workflowRuns(input: {}) {
         id
         entityInputs {

--- a/example-queries/workflow-runs-query-empty.graphql
+++ b/example-queries/workflow-runs-query-empty.graphql
@@ -1,0 +1,13 @@
+query WorkflowRunsQuery($unused: String) {
+    workflowRuns(input: {}) {
+        id
+        entityInputs {
+            edges {
+                node {
+                    entityType
+                    inputEntityId
+                }
+            }
+        }
+    }
+}

--- a/example-queries/workflow-runs-query-id-list.graphql
+++ b/example-queries/workflow-runs-query-id-list.graphql
@@ -6,10 +6,9 @@ query ValidConsensusGenomeWorkflowRunsQuery(
         input: {
         where: { id: { _in: $workflowRunIds } }
         todoRemove: { authenticityToken: $authenticityToken }
-        }
-    ) {
+    }) {
         id
         ownerUserId
         status
     }
-    }
+}

--- a/example-queries/workflow-runs-query-id-list.graphql
+++ b/example-queries/workflow-runs-query-id-list.graphql
@@ -1,0 +1,15 @@
+query ValidConsensusGenomeWorkflowRunsQuery(
+    $workflowRunIds: [String]
+    $authenticityToken: String!
+    ) {
+    workflowRuns(
+        input: {
+        where: { id: { _in: $workflowRunIds } }
+        todoRemove: { authenticityToken: $authenticityToken }
+        }
+    ) {
+        id
+        ownerUserId
+        status
+    }
+    }

--- a/example-queries/workflow-runs-query-order-by.graphql
+++ b/example-queries/workflow-runs-query-order-by.graphql
@@ -1,0 +1,17 @@
+query TestQuery($unused: String) {
+    workflowRuns(input: {
+        orderBy: {
+            startedAt: "ASC"
+        }
+    }) {
+        id
+        entityInputs {
+            edges {
+                node {
+                    fieldName
+                    inputEntityId
+                }
+            }
+        }
+    }
+}

--- a/example-queries/workflow-runs-query-order-by.graphql
+++ b/example-queries/workflow-runs-query-order-by.graphql
@@ -1,4 +1,4 @@
-query TestQuery($unused: String) {
+query TestQuery {
     workflowRuns(input: {
         orderBy: {
             startedAt: "ASC"

--- a/json-schemas/consensusGenomesRequest.json
+++ b/json-schemas/consensusGenomesRequest.json
@@ -14,89 +14,6 @@
                             }
                         }
                     }
-                },
-                "taxon": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "object",
-                            "properties": {
-                                "_in": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "sequencingRead": {
-                    "type": "object",
-                    "properties": {
-                        "sample": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "object",
-                                    "properties": {
-                                        "_in": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "name": {
-                                    "type": "object",
-                                    "properties": {
-                                        "_like": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "collectionLocation": {
-                                    "type": "object",
-                                    "properties": {
-                                        "_in": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "sampleType": {
-                                    "type": "object",
-                                    "properties": {
-                                        "_in": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "hostOrganism": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
-                                            "type": "object",
-                                            "properties": {
-                                                "_in": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
                 }
             }
         },
@@ -148,41 +65,22 @@
                 }
             }
         },
-        "sequencingReadsInput": {
-            "type": "object",
-            "properties": {
-                "where": {
-                    "type": "object",
-                    "properties": {
-                        "consensusGenomes": {
-                            "taxon": {
-                                "type": "object",
-                                "properties": {
-                                    "producingRunId": {
-                                        "type": "object",
-                                        "properties": {
-                                            "_in": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "integer"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "todoRemove": {
             "type": "object",
             "properties": {
                 "domain": {
                     "type": "string"
                 },
+                "workflow": {
+                    "type": "string"
+                },
+                "projectId": {
+                    "type": "string"
+                },
                 "visibility": {
+                    "type": "string"
+                },
+                "search": {
                     "type": "string"
                 },
                 "time": {
@@ -209,23 +107,29 @@
                         "type": "integer"
                     }
                 },
-                "offset": {
-                    "type": "integer"
+                "locationV2": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
-                "limit": {
-                    "type": "integer"
-                },
-                "workflow": {
-                    "type": "string"
-                },
-                "projectId": {
-                    "type": "string"
+                "tissue": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "orderBy": {
                     "type": "string"
                 },
                 "orderDir": {
                     "type": "string"
+                },
+                "offset": {
+                    "type": "integer"
+                },
+                "limit": {
+                    "type": "integer"
                 }
             }
         }

--- a/json-schemas/consensusGenomesRequest.json
+++ b/json-schemas/consensusGenomesRequest.json
@@ -1,0 +1,233 @@
+{
+    "type": "object",
+    "properties": {
+        "where": {
+            "type": "object",
+            "properties": {
+                "producingRunId": {
+                    "type": "object",
+                    "properties": {
+                        "_in": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "taxon": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "sequencingRead": {
+                    "type": "object",
+                    "properties": {
+                        "sample": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_like": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "collectionLocation": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "sampleType": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "hostOrganism": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "object",
+                                            "properties": {
+                                                "_in": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "orderBy": {
+            "type": "object",
+            "properties": {
+                "accession": {
+                    "type": "object",
+                    "properties": {
+                        "accessionId": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "coverageDepth": {
+                            "type": "string"
+                        },
+                        "totalReads": {
+                            "type": "string"
+                        },
+                        "gcPercent": {
+                            "type": "string"
+                        },
+                        "refSnps": {
+                            "type": "string"
+                        },
+                        "percentIdentity": {
+                            "type": "string"
+                        },
+                        "nActg": {
+                            "type": "string"
+                        },
+                        "percentGenomeCalled": {
+                            "type": "string"
+                        },
+                        "nMissing": {
+                            "type": "string"
+                        },
+                        "nAmbiguous": {
+                            "type": "string"
+                        },
+                        "referenceGenomeLength": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "sequencingReadsInput": {
+            "type": "object",
+            "properties": {
+                "where": {
+                    "type": "object",
+                    "properties": {
+                        "consensusGenomes": {
+                            "taxon": {
+                                "type": "object",
+                                "properties": {
+                                    "producingRunId": {
+                                        "type": "object",
+                                        "properties": {
+                                            "_in": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "todoRemove": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string"
+                },
+                "visibility": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "host": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "taxaLevels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "taxons": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "offset": {
+                    "type": "integer"
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "workflow": {
+                    "type": "string"
+                },
+                "projectId": {
+                    "type": "string"
+                },
+                "orderBy": {
+                    "type": "string"
+                },
+                "orderDir": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -1,0 +1,162 @@
+{
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "taxon": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name"]
+            },
+            "referenceGenome": {
+                "type": "object",
+                "properties": {
+                    "accessionId": {
+                        "type": "string"
+                    },
+                    "accessionName": {
+                        "type": "string"
+                    }
+                }
+            },
+            "metric": {
+                "type": "object",
+                "properties": {
+                    "coverageDepth": {
+                        "type": "number"
+                    },
+                    "totalReads": {
+                        "type": "integer"
+                    },
+                    "gcPercent": {
+                        "type": "number"
+                    },
+                    "refSnps": {
+                        "type": "integer"
+                    },
+                    "percentIdentity": {
+                        "type": "number"
+                    },
+                    "nActg": {
+                        "type": "integer"
+                    },
+                    "percentGenomeCalled": {
+                        "type": "number"
+                    },
+                    "nMissing": {
+                        "type": "integer"
+                    },
+                    "nAmbiguous": {
+                        "type": "integer"
+                    },
+                    "referenceGenomeLength": {
+                        "type": "number"
+                    }
+                }
+            },
+            "sequencingRead": {
+                "type": "object",
+                "properties": {
+                    "nucleicAcid": {
+                        "type": "string"
+                    },
+                    "protocol": {
+                        "type": "string"
+                    },
+                    "medakaModel": {
+                        "type": "string"
+                    },
+                    "technology": {
+                        "type": "string"
+                    },
+                    "sample": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "railsSampleId": {
+                                "type": "integer"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "notes": {
+                                "type": "string"
+                            },
+                            "collectionLocation": {
+                                "type": "string"
+                            },
+                            "sampleType": {
+                                "type": "string"
+                            },
+                            "waterControl": {
+                                "type": "boolean"
+                            },
+                            "hostOrganism": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "collection": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "public": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "ownerUser": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "metadatas": {
+                                "type": "object",
+                                "properties": {
+                                    "edges": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "node": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "fieldName": {
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["fieldName", "value"]
+                                                }
+                                            },
+                                            "required": ["node"]
+                                        }
+                                    }
+                                },
+                                "required": ["edges"]
+                            }
+                        },
+                        "required": ["name", "collectionLocation", "sampleType", "metadatas"]
+                    }
+                },
+                "required": ["nucleicAcid", "technology", "taxon", "consensusGenomes"]
+            }
+        }
+    }
+}

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -3,6 +3,9 @@
     "items": {
         "type": "object",
         "properties": {
+            "producingRunId": {
+                "type": "string"
+            },
             "taxon": {
                 "type": "object",
                 "properties": {
@@ -85,9 +88,6 @@
                     "sample": {
                         "type": "object",
                         "properties": {
-                            "id": {
-                                "type": "string"
-                            },
                             "railsSampleId": {
                                 "type": "integer"
                             },

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -73,6 +73,15 @@
                     "technology": {
                         "type": "string"
                     },
+                    "taxon": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name"]
+                    },
                     "sample": {
                         "type": "object",
                         "properties": {
@@ -155,7 +164,7 @@
                         "required": ["name", "collectionLocation", "sampleType", "metadatas"]
                     }
                 },
-                "required": ["nucleicAcid", "technology", "taxon", "consensusGenomes"]
+                "required": ["nucleicAcid", "technology"]
             }
         }
     }

--- a/json-schemas/samplesRequest.json
+++ b/json-schemas/samplesRequest.json
@@ -45,10 +45,10 @@
                         }
                     }
                 },
-                "hostTaxon": {
+                "hostOrganism": {
                     "type": "object",
                     "properties": {
-                        "upstreamDatabaseIdentifier": {
+                        "name": {
                             "type": "object",
                             "properties": {
                                 "_in": {
@@ -64,6 +64,22 @@
                 "sequencingReads": {
                     "type": "object",
                     "properties": {
+                        "taxon": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
                         "consensusGenomes": {
                             "type": "object",
                             "properties": {
@@ -77,17 +93,6 @@
                                                     "type": "array",
                                                     "items": {
                                                         "type": "string"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "producingRunId": {
-                                            "type": "object",
-                                            "properties": {
-                                                "_in": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "integer"
                                                     }
                                                 }
                                             }
@@ -117,17 +122,36 @@
                 "where": {
                     "type": "object",
                     "properties": {
+                        "taxon": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
                         "consensusGenomes": {
-                            "taxon": {
-                                "type": "object",
-                                "properties": {
-                                    "producingRunId": {
-                                        "type": "object",
-                                        "properties": {
-                                            "_in": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "integer"
+                            "type": "object",
+                            "properties": {
+                                "taxon": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "object",
+                                            "properties": {
+                                                "_in": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
                                                 }
                                             }
                                         }

--- a/json-schemas/samplesResponse.json
+++ b/json-schemas/samplesResponse.json
@@ -8,8 +8,8 @@
             },
             "railsSampleId": {
                 "type": "integer"
-            },
-            "required": ["id"]
-        }
+            }
+        },
+        "required": ["id"]
     }
 }

--- a/json-schemas/sequencingReadsRequest.json
+++ b/json-schemas/sequencingReadsRequest.json
@@ -1,0 +1,250 @@
+{
+    "type": "object",
+    "properties": {
+        "where": {
+            "type": "object",
+            "properties": {
+                "sample": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "object",
+                            "properties": {
+                                "_like": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "collectionLocation": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "sampleType": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "hostOrganism": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "consensusGenomes": {
+                    "type": "object",
+                    "properties": {
+                        "producingRunId": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "taxon": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "orderBy": {
+            "type": "object",
+            "properties": {
+                "protocol": {
+                    "type": "string"
+                },
+                "technology": {
+                    "type": "string"
+                },
+                "medakaModel": {
+                    "type": "string"
+                },
+                "nucleicAcid": {
+                    "type": "string"
+                },
+                "sample": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        },
+                        "sampleType": {
+                            "type": "string"
+                        },
+                        "waterControl": {
+                            "type": "string"
+                        },
+                        "collectionLocation": {
+                            "type": "string"
+                        },
+                        "hostOrganism": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "metadata": {
+                            "type": "object",
+                            "properties": {
+                                "fieldName": {
+                                    "type": "string"
+                                },
+                                "dir": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "consensusGenomesInput": {
+            "type": "object",
+            "properties": {
+                "where": {
+                    "type": "object",
+                    "properties": {
+                        "producingRunId": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "taxon": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "todoRemove": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string"
+                },
+                "visibility": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "host": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "taxaLevels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "taxons": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "offset": {
+                    "type": "integer"
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "workflow": {
+                    "type": "string"
+                },
+                "projectId": {
+                    "type": "string"
+                },
+                "orderBy": {
+                    "type": "string"
+                },
+                "orderDir": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/json-schemas/sequencingReadsRequest.json
+++ b/json-schemas/sequencingReadsRequest.json
@@ -4,96 +4,13 @@
         "where": {
             "type": "object",
             "properties": {
-                "sample": {
+                "id": {
                     "type": "object",
                     "properties": {
-                        "id": {
-                            "type": "object",
-                            "properties": {
-                                "_in": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "object",
-                            "properties": {
-                                "_like": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "collectionLocation": {
-                            "type": "object",
-                            "properties": {
-                                "_in": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "sampleType": {
-                            "type": "object",
-                            "properties": {
-                                "_in": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "hostOrganism": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "object",
-                                    "properties": {
-                                        "_in": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "consensusGenomes": {
-                    "type": "object",
-                    "properties": {
-                        "producingRunId": {
-                            "type": "object",
-                            "properties": {
-                                "_in": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "taxon": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "object",
-                                    "properties": {
-                                        "_in": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
+                        "_in": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
                             }
                         }
                     }
@@ -172,22 +89,6 @@
                                     }
                                 }
                             }
-                        },
-                        "taxon": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "object",
-                                    "properties": {
-                                        "_in": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
                         }
                     }
                 }
@@ -199,7 +100,16 @@
                 "domain": {
                     "type": "string"
                 },
+                "workflow": {
+                    "type": "string"
+                },
+                "projectId": {
+                    "type": "string"
+                },
                 "visibility": {
+                    "type": "string"
+                },
+                "search": {
                     "type": "string"
                 },
                 "time": {
@@ -226,23 +136,29 @@
                         "type": "integer"
                     }
                 },
-                "offset": {
-                    "type": "integer"
+                "locationV2": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
-                "limit": {
-                    "type": "integer"
-                },
-                "workflow": {
-                    "type": "string"
-                },
-                "projectId": {
-                    "type": "string"
+                "tissue": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "orderBy": {
                     "type": "string"
                 },
                 "orderDir": {
                     "type": "string"
+                },
+                "offset": {
+                    "type": "integer"
+                },
+                "limit": {
+                    "type": "integer"
                 }
             }
         }

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -3,6 +3,9 @@
     "items": {
         "type": "object",
         "properties": {
+            "id": {
+                "type": "string"
+            },
             "nucleicAcid": {
                 "type": "string"
             },
@@ -27,9 +30,6 @@
             "sample": {
                 "type": "object",
                 "properties": {
-                    "id": {
-                        "type": "string"
-                    },
                     "railsSampleId": {
                         "type": "integer"
                     },
@@ -117,6 +117,9 @@
                                 "node": {
                                     "type": "object",
                                     "properties": {
+                                        "producingRunId": {
+                                            "type": "string"
+                                        },
                                         "taxon": {
                                             "type": "object",
                                             "properties": {
@@ -182,6 +185,6 @@
                 "required": ["edges"]
             }
         },
-        "required": ["nucleicAcid", "technology", "consensusGenomes"]
+        "required": ["id", "nucleicAcid", "technology", "consensusGenomes"]
     }
 }

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -15,6 +15,15 @@
             "technology": {
                 "type": "string"
             },
+            "taxon": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name"]
+            },
             "sample": {
                 "type": "object",
                 "properties": {
@@ -173,6 +182,6 @@
                 "required": ["edges"]
             }
         },
-        "required": ["nucleicAcid", "technology", "taxon", "consensusGenomes"]
+        "required": ["nucleicAcid", "technology", "consensusGenomes"]
     }
 }

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -168,11 +168,11 @@
                             },
                             "required": ["node"]
                         }
-                    },
-                    "required": ["edges"]
-                }
-            },
-            "required": ["nucleicAcid", "technology", "taxon", "consensusGenomes"]
-        }
+                    }
+                },
+                "required": ["edges"]
+            }
+        },
+        "required": ["nucleicAcid", "technology", "taxon", "consensusGenomes"]
     }
 }

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -1,0 +1,178 @@
+{
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "nucleicAcid": {
+                "type": "string"
+            },
+            "protocol": {
+                "type": "string"
+            },
+            "medakaModel": {
+                "type": "string"
+            },
+            "technology": {
+                "type": "string"
+            },
+            "sample": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "railsSampleId": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "notes": {
+                        "type": "string"
+                    },
+                    "collectionLocation": {
+                        "type": "string"
+                    },
+                    "sampleType": {
+                        "type": "string"
+                    },
+                    "waterControl": {
+                        "type": "boolean"
+                    },
+                    "hostOrganism": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name"]
+                    },
+                    "collection": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "public": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "ownerUser": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "metadatas": {
+                        "type": "object",
+                        "properties": {
+                            "edges": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "node": {
+                                            "type": "object",
+                                            "properties": {
+                                                "fieldName": {
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": ["fieldName", "value"]
+                                        }
+                                    },
+                                    "required": ["node"]
+                                }
+                            }
+                        },
+                        "required": ["edges"]
+                    }
+                },
+                "required": ["name", "collectionLocation", "sampleType", "metadatas"]
+            },
+            "consensusGenomes": {
+                "type": "object",
+                "properties": {
+                    "edges": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "node": {
+                                    "type": "object",
+                                    "properties": {
+                                        "taxon": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": ["name"]
+                                        },
+                                        "referenceGenome": {
+                                            "type": "object",
+                                            "properties": {
+                                                "accessionId": {
+                                                    "type": "string"
+                                                },
+                                                "accessionName": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "metric": {
+                                            "type": "object",
+                                            "properties": {
+                                                "coverageDepth": {
+                                                    "type": "number"
+                                                },
+                                                "totalReads": {
+                                                    "type": "integer"
+                                                },
+                                                "gcPercent": {
+                                                    "type": "number"
+                                                },
+                                                "refSnps": {
+                                                    "type": "integer"
+                                                },
+                                                "percentIdentity": {
+                                                    "type": "number"
+                                                },
+                                                "nActg": {
+                                                    "type": "integer"
+                                                },
+                                                "percentGenomeCalled": {
+                                                    "type": "number"
+                                                },
+                                                "nMissing": {
+                                                    "type": "integer"
+                                                },
+                                                "nAmbiguous": {
+                                                    "type": "integer"
+                                                },
+                                                "referenceGenomeLength": {
+                                                    "type": "number"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "required": ["node"]
+                        }
+                    },
+                    "required": ["edges"]
+                }
+            },
+            "required": ["nucleicAcid", "technology", "taxon", "consensusGenomes"]
+        }
+    }
+}

--- a/json-schemas/workflowRunsRequest.json
+++ b/json-schemas/workflowRunsRequest.json
@@ -65,6 +65,22 @@
             "properties": {
                 "startedAt": {
                     "type": "string"
+                },
+                "workflowVersion": {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "type": "string"
+                        },
+                        "workflow": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -134,6 +134,7 @@ export const resolvers: Resolvers = {
         const sampleInfo = sample?.info;
         const sampleMetadata = sample?.metadata;
         return {
+          producingRunId: run.id?.toString(),
           taxon: {
             name: inputs?.taxon_name,
           },
@@ -162,7 +163,6 @@ export const resolvers: Resolvers = {
               name: inputs?.taxon_name,
             },
             sample: {
-              id: sample?.id,
               railsSampleId: sample?.id,
               name: sampleInfo?.name,
               notes: sampleInfo?.sample_notes,
@@ -406,8 +406,8 @@ export const resolvers: Resolvers = {
 
       return workflow_runs.map((run): query_samples_items => {
         return {
-          id: run.sample?.id?.toString(),
-          railsSampleId: run.sample?.id?.toString(),
+          id: run.sample?.info?.id?.toString(),
+          railsSampleId: run.sample?.info?.id?.toString(),
         };
       });
     },
@@ -461,6 +461,7 @@ export const resolvers: Resolvers = {
         const sampleInfo = sample?.info;
         const sampleMetadata = sample?.metadata;
         return {
+          id: sampleInfo?.id?.toString(),
           nucleicAcid: sampleMetadata?.nucleotide_type,
           protocol: inputs?.wetlab_protocol,
           medakaModel: inputs?.medaka_model,
@@ -469,8 +470,7 @@ export const resolvers: Resolvers = {
             name: inputs?.taxon_name,
           },
           sample: {
-            id: sample?.id,
-            railsSampleId: sample?.id,
+            railsSampleId: sampleInfo?.id?.toString(),
             name: sampleInfo?.name,
             notes: sampleInfo?.sample_notes,
             collectionLocation: sampleMetadata?.collection_location_v2,
@@ -494,6 +494,7 @@ export const resolvers: Resolvers = {
             edges: [
               {
                 node: {
+                  producingRunId: run.id?.toString(),
                   taxon: {
                     name: inputs?.taxon_name,
                   },

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -101,18 +101,17 @@ export const resolvers: Resolvers = {
             //  -- DiscoveryView.tsx
             //     ...this.getConditions(workflow)
             projectId: input?.todoRemove?.projectId,
-            search: input?.where?.sequencingRead?.sample?.name?._like,
+            search: input?.todoRemove?.search,
             orderBy: input?.todoRemove?.orderBy,
             orderDir: input?.todoRemove?.orderDir,
             //  --- DiscoveryView.tsx
             //      filters: {
             host: input?.todoRemove?.host,
-            locationV2:
-              input?.where?.sequencingRead?.sample?.collectionLocation?._in,
+            locationV2: input?.todoRemove?.locationV2,
             taxon: input?.todoRemove?.taxons,
             taxaLevels: input?.todoRemove?.taxaLevels,
             time: input?.todoRemove?.time,
-            tissue: input?.where?.sequencingRead?.sample?.sampleType?._in,
+            tissue: input?.todoRemove?.tissue,
             visibility: input?.todoRemove?.visibility,
             workflow: input?.todoRemove?.workflow,
             //  - DiscoveryDataLayer.ts
@@ -381,7 +380,7 @@ export const resolvers: Resolvers = {
             orderDir: input?.orderBy?.dir,
             //  --- DiscoveryView.tsx
             //      filters: {
-            host: input?.where?.hostTaxon?.upstreamDatabaseIdentifier?._in,
+            host: input?.where?.hostOrganism?.name?._in,
             locationV2: input?.where?.collectionLocation?._in,
             taxon: input?.todoRemove?.taxons,
             taxaLevels: input?.todoRemove?.taxaLevels,
@@ -426,17 +425,17 @@ export const resolvers: Resolvers = {
             //  -- DiscoveryView.tsx
             //     ...this.getConditions(workflow)
             projectId: input?.todoRemove?.projectId,
-            search: input?.where?.sample?.name?._like,
+            search: input?.todoRemove?.search,
             orderBy: input?.todoRemove?.orderBy,
             orderDir: input?.todoRemove?.orderDir,
             //  --- DiscoveryView.tsx
             //      filters: {
             host: input?.todoRemove?.host,
-            locationV2: input?.where?.sample?.collectionLocation?._in,
+            locationV2: input?.todoRemove?.locationV2,
             taxon: input?.todoRemove?.taxons,
             taxaLevels: input?.todoRemove?.taxaLevels,
             time: input?.todoRemove?.time,
-            tissue: input?.where?.sample?.sampleType?._in,
+            tissue: input?.todoRemove?.tissue,
             visibility: input?.todoRemove?.visibility,
             workflow: input?.todoRemove?.workflow,
             //  - DiscoveryDataLayer.ts

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -158,6 +158,9 @@ export const resolvers: Resolvers = {
             protocol: inputs?.wetlab_protocol,
             medakaModel: inputs?.medaka_model,
             technology: inputs?.technology,
+            taxon: {
+              name: inputs?.taxon_name,
+            },
             sample: {
               id: sample?.id,
               railsSampleId: sample?.id,
@@ -462,6 +465,9 @@ export const resolvers: Resolvers = {
           protocol: inputs?.wetlab_protocol,
           medakaModel: inputs?.medaka_model,
           technology: inputs?.technology,
+          taxon: {
+            name: inputs?.taxon_name,
+          },
           sample: {
             id: sample?.id,
             railsSampleId: sample?.id,

--- a/tests/BulkDownloadCGOverview.test.ts
+++ b/tests/BulkDownloadCGOverview.test.ts
@@ -1,5 +1,5 @@
 import { ExecuteMeshFn } from "@graphql-mesh/runtime";
-import { getBulkDownloadCGOverviewExampleQuery, getBulkDownloadCGOverviewResponse } from "./utils/ExampleQueryFiles";
+import { getExampleQuery, getSampleResponse } from "./utils/ExampleQueryFiles";
 import { getMeshInstance } from "./utils/MeshInstance";
 
 import * as httpUtils from "../utils/httpUtils";
@@ -17,23 +17,26 @@ describe.only("BulkDownloadCGOverview Query", () => {
     const mesh$ = await getMeshInstance();
     // Load BulkDownloadCGOverview example query
     ({ execute } = mesh$);
-    query = getBulkDownloadCGOverviewExampleQuery();
+    query = getExampleQuery("bulk-download-cg-overview-query");
   });
 
   describe("BulkDownloadCGOverview successful response", () => {
-    const bulkDownloadCGOverviewResponse = JSON.parse(getBulkDownloadCGOverviewResponse());
+    const bulkDownloadCGOverviewResponse = getSampleResponse("cgOverview");
 
     it("should give correct response", async () => {
-      (httpUtils.postWithCSRF as jest.Mock).mockImplementation(() => bulkDownloadCGOverviewResponse);
+      (httpUtils.postWithCSRF as jest.Mock).mockImplementation(
+        () => bulkDownloadCGOverviewResponse
+      );
       const result = await execute(query, {
         authenticityToken: "authtoken1234",
-        downloadType: "consensus_genome_overview", 
+        downloadType: "consensus_genome_overview",
         includeMetadata: false,
-        workflow: "consensus_genome", 
-        workflowRunIds: [1991, 2007]
+        workflow: "consensus_genome",
+        workflowRunIds: [1991, 2007],
       });
-      expect(result.data.BulkDownloadCGOverview.cgOverviewRows).toStrictEqual(bulkDownloadCGOverviewResponse.cg_overview_rows);
+      expect(result.data.BulkDownloadCGOverview.cgOverviewRows).toStrictEqual(
+        bulkDownloadCGOverviewResponse.cg_overview_rows
+      );
     });
   });
-
 });

--- a/tests/ConsensusGenomesQuery.test.ts
+++ b/tests/ConsensusGenomesQuery.test.ts
@@ -1,0 +1,175 @@
+import { ExecuteMeshFn } from "@graphql-mesh/runtime";
+import { getZipLinkExampleQuery } from "./utils/ExampleQueryFiles";
+import { getMeshInstance } from "./utils/MeshInstance";
+import * as httpUtils from "../utils/httpUtils";
+jest.spyOn(httpUtils, "get");
+beforeEach(() => {
+  (httpUtils.get as jest.Mock).mockClear();
+});
+const query = `
+    query TestQuery($unused: String) {
+      consensusGenomes(input: {
+        where: {
+            sample: {
+                sequencingRead: {
+                    name: {
+                      _like: "abc",
+                    }
+                }
+            }
+        },
+      }) {
+        sequencingRead {
+            sample {
+                id
+                metadatas {
+                  edges {
+                    node {
+                        fieldName
+                        value
+                    }
+                }
+            }
+        }
+        consensusGenomes {
+          edges {
+            node {
+              taxon {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+`;
+
+describe("consensusGenomes query:", () => {
+  let execute: ExecuteMeshFn;
+
+  beforeEach(async () => {
+    const mesh$ = await getMeshInstance();
+    ({ execute } = mesh$);
+  });
+
+  it("Returns empty list", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [],
+    }));
+    const response = await execute(query, {});
+
+    expect(httpUtils.get).toHaveBeenCalledWith(
+      "/workflow_runs.json?&mode=with_sample_info&search=abc",
+      expect.anything(),
+      expect.anything()
+    );
+    expect(response.data.sequencingReads).toHaveLength(0);
+  });
+
+  it("Returns nested fields", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {
+            id: 123,
+          },
+          inputs: {
+            taxon_name: "Taxon1",
+          },
+        },
+        {
+          sample: {
+            id: 456,
+          },
+          inputs: {
+            taxon_name: "Taxon2",
+          },
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    expect(result.data.seuqencingReads).toHaveLength(2);
+    expect(result.data.sequencingReads[0]).toEqual(
+      expect.objectContaining({
+        sample: {
+          id: 123,
+        },
+        consensusGenomes: {
+          edges: [
+            {
+              node: {
+                taxon: {
+                  name: "Taxon1",
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+    expect(result.data.samples[1]).toEqual(
+      expect.objectContaining({
+        sample: {
+          id: 456,
+        },
+        consensusGenomes: {
+          edges: [
+            {
+              node: {
+                taxon: {
+                  name: "Taxon2",
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  it("Returns metadata", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {
+            metadata: {
+              key1: "value1",
+              nucleotide_type: "DNA",
+              key2: "value2",
+              key3: "value3",
+            },
+          },
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    const metadataFields =
+      result.data.sequencingReads[0].sample.metadatas.edges.map(
+        (edge) => edge.node.fieldName
+      );
+    expect(metadataFields).toHaveLength(3);
+    expect(metadataFields[0]).toEqual("key1");
+    expect(metadataFields[1]).toEqual("key2");
+    expect(metadataFields[2]).toEqual("key3");
+  });
+
+  it("Returns empty metadata", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {},
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    expect(result.data.sequencingReads[0].sample.metadatas.edges).toHaveLength(
+      0
+    );
+  });
+});

--- a/tests/ConsensusGenomesQuery.test.ts
+++ b/tests/ConsensusGenomesQuery.test.ts
@@ -1,6 +1,7 @@
 import { ExecuteMeshFn } from "@graphql-mesh/runtime";
 import { getMeshInstance } from "./utils/MeshInstance";
 import * as httpUtils from "../utils/httpUtils";
+import { getExampleQuery } from "./utils/ExampleQueryFiles";
 
 jest.spyOn(httpUtils, "get");
 
@@ -8,37 +9,7 @@ beforeEach(() => {
   (httpUtils.get as jest.Mock).mockClear();
 });
 
-const query = `
-    query TestQuery($unused: String) {
-      consensusGenomes(input: {
-        where: {
-          producingRunId: {
-            _in: ["abc", "def"]
-          }
-        }
-        todoRemove: {
-          search: "abc"
-        }
-      }) {
-        producingRunId
-        taxon {
-          name
-        }
-        sequencingRead {
-          sample {
-            metadatas {
-              edges {
-                node {
-                  fieldName
-                  value
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-`;
+const query = getExampleQuery("consensus-genomes-query");
 
 describe("consensusGenomes query:", () => {
   let execute: ExecuteMeshFn;

--- a/tests/CreateBulkDownload.test.ts
+++ b/tests/CreateBulkDownload.test.ts
@@ -1,5 +1,5 @@
 import { ExecuteMeshFn } from "@graphql-mesh/runtime";
-import { getCreateBulkDownloadExampleMutation, getCreateBulkDownloadResponse } from "./utils/ExampleQueryFiles";
+import { getExampleQuery, getSampleResponse } from "./utils/ExampleQueryFiles";
 import { getMeshInstance } from "./utils/MeshInstance";
 
 import * as httpUtils from "../utils/httpUtils";
@@ -17,23 +17,25 @@ describe.only("CreateBulkDownload Query", () => {
     const mesh$ = await getMeshInstance();
     // Load CreateBulkDownload example query
     ({ execute } = mesh$);
-    query = getCreateBulkDownloadExampleMutation();
+    query = getExampleQuery("create-bulk-download-query");
   });
 
   describe("CreateBulkDownload successful response", () => {
-    const createBulkDownloadResponse = JSON.parse(getCreateBulkDownloadResponse());
-
+    const createBulkDownloadResponse = getSampleResponse("bulkDownload");
     it("should give correct response", async () => {
-      (httpUtils.postWithCSRF as jest.Mock).mockImplementation(() => createBulkDownloadResponse);
+      (httpUtils.postWithCSRF as jest.Mock).mockImplementation(
+        () => createBulkDownloadResponse
+      );
       const result = await execute(query, {
         authenticityToken: "authtoken1234",
-        downloadType: "consensus_genome_intermediate_output_files", 
-        downloadFormat: "Separate Files", 
-        workflow: "consensus_genome", 
-        workflowRunIds: [1991, 2007]
+        downloadType: "consensus_genome_intermediate_output_files",
+        downloadFormat: "Separate Files",
+        workflow: "consensus_genome",
+        workflowRunIds: [1991, 2007],
       });
-      expect(result.data.CreateBulkDownload).toStrictEqual(createBulkDownloadResponse);
+      expect(result.data.CreateBulkDownload).toStrictEqual(
+        createBulkDownloadResponse
+      );
     });
   });
-
 });

--- a/tests/SamplesQuery.test.ts
+++ b/tests/SamplesQuery.test.ts
@@ -1,27 +1,15 @@
 import { ExecuteMeshFn } from "@graphql-mesh/runtime";
-import { getZipLinkExampleQuery } from "./utils/ExampleQueryFiles";
 import { getMeshInstance } from "./utils/MeshInstance";
 
 import * as httpUtils from "../utils/httpUtils";
+import { getExampleQuery } from "./utils/ExampleQueryFiles";
 jest.spyOn(httpUtils, "get");
+
+const query = getExampleQuery("samples-query");
 
 beforeEach(() => {
   (httpUtils.get as jest.Mock).mockClear();
 });
-
-const query = `
-    query TestQuery($unused: String) {
-      samples(input: {
-        where: {
-          name: {
-            _like: "abc",
-          }
-        },
-      }) {
-        id
-      }
-    }
-`;
 
 describe("samples query:", () => {
   let execute: ExecuteMeshFn;

--- a/tests/SamplesQuery.test.ts
+++ b/tests/SamplesQuery.test.ts
@@ -50,10 +50,10 @@ describe("samples query:", () => {
     (httpUtils.get as jest.Mock).mockImplementation(() => ({
       workflow_runs: [
         {
-          sample: { id: 123 },
+          sample: { info: { id: 123 } },
         },
         {
-          sample: { id: 456 },
+          sample: { info: { id: 456 } },
         },
       ],
     }));

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -1,6 +1,7 @@
 import { ExecuteMeshFn } from "@graphql-mesh/runtime";
 import { getMeshInstance } from "./utils/MeshInstance";
 import * as httpUtils from "../utils/httpUtils";
+import { getExampleQuery } from "./utils/ExampleQueryFiles";
 
 jest.spyOn(httpUtils, "get");
 
@@ -8,41 +9,7 @@ beforeEach(() => {
   (httpUtils.get as jest.Mock).mockClear();
 });
 
-const query = `
-    query TestQuery($unused: String) {
-      sequencingReads(input: {
-        where: {
-          id: {
-            _in: ["abc", "def"]
-          }
-        }
-        todoRemove: {
-          search: "abc"
-        }
-      }) {
-        id
-        sample {
-          metadatas {
-            edges {
-              node {
-                fieldName
-                value
-              }
-            }
-          }
-        }
-        consensusGenomes {
-          edges {
-            node {
-              taxon {
-                name
-              }
-            }
-          }
-        }
-      }
-    }
-`;
+const query = getExampleQuery("sequencing-reads-query");
 
 describe("sequencingReads query:", () => {
   let execute: ExecuteMeshFn;

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -1,0 +1,171 @@
+import { ExecuteMeshFn } from "@graphql-mesh/runtime";
+import { getZipLinkExampleQuery } from "./utils/ExampleQueryFiles";
+import { getMeshInstance } from "./utils/MeshInstance";
+import * as httpUtils from "../utils/httpUtils";
+jest.spyOn(httpUtils, "get");
+beforeEach(() => {
+  (httpUtils.get as jest.Mock).mockClear();
+});
+const query = `
+    query TestQuery($unused: String) {
+      sequencingReads(input: {
+        where: {
+          sample: {
+              name: {
+                _like: "abc",
+              }
+          }
+        },
+      }) {
+        sample {
+            id
+            metadatas {
+              edges {
+                node {
+                    fieldName
+                    value
+                }
+            }
+        }
+        consensusGenomes {
+          edges {
+            node {
+              taxon {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+`;
+
+describe("sequencingReads query:", () => {
+  let execute: ExecuteMeshFn;
+
+  beforeEach(async () => {
+    const mesh$ = await getMeshInstance();
+    ({ execute } = mesh$);
+  });
+
+  it("Returns empty list", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [],
+    }));
+    const response = await execute(query, {});
+
+    expect(httpUtils.get).toHaveBeenCalledWith(
+      "/workflow_runs.json?&mode=with_sample_info&search=abc",
+      expect.anything(),
+      expect.anything()
+    );
+    expect(response.data.sequencingReads).toHaveLength(0);
+  });
+
+  it("Returns nested fields", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {
+            id: 123,
+          },
+          inputs: {
+            taxon_name: "Taxon1",
+          },
+        },
+        {
+          sample: {
+            id: 456,
+          },
+          inputs: {
+            taxon_name: "Taxon2",
+          },
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    expect(result.data.seuqencingReads).toHaveLength(2);
+    expect(result.data.sequencingReads[0]).toEqual(
+      expect.objectContaining({
+        sample: {
+          id: 123,
+        },
+        consensusGenomes: {
+          edges: [
+            {
+              node: {
+                taxon: {
+                  name: "Taxon1",
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+    expect(result.data.samples[1]).toEqual(
+      expect.objectContaining({
+        sample: {
+          id: 456,
+        },
+        consensusGenomes: {
+          edges: [
+            {
+              node: {
+                taxon: {
+                  name: "Taxon2",
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  it("Returns metadata", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {
+            metadata: {
+              key1: "value1",
+              nucleotide_type: "DNA",
+              key2: "value2",
+              key3: "value3",
+            },
+          },
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    const metadataFields =
+      result.data.sequencingReads[0].sample.metadatas.edges.map(
+        (edge) => edge.node.fieldName
+      );
+    expect(metadataFields).toHaveLength(3);
+    expect(metadataFields[0]).toEqual("key1");
+    expect(metadataFields[1]).toEqual("key2");
+    expect(metadataFields[2]).toEqual("key3");
+  });
+
+  it("Returns empty metadata", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {},
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    expect(result.data.sequencingReads[0].sample.metadatas.edges).toHaveLength(
+      0
+    );
+  });
+});

--- a/tests/WorkflowRunsQuery.test.ts
+++ b/tests/WorkflowRunsQuery.test.ts
@@ -1,5 +1,5 @@
 import { ExecuteMeshFn } from "@graphql-mesh/runtime";
-import { getZipLinkExampleQuery } from "./utils/ExampleQueryFiles";
+import { getExampleQuery } from "./utils/ExampleQueryFiles";
 import { getMeshInstance } from "./utils/MeshInstance";
 
 import * as httpUtils from "../utils/httpUtils";
@@ -20,21 +20,6 @@ describe("workflowRuns query:", () => {
   });
 
   it("Returns input sample", async () => {
-    const query = `
-        query TestQuery($unused: String) {
-            workflowRuns(input: {}) {
-                id
-                entityInputs {
-                    edges {
-                        node {
-                            entityType
-                            inputEntityId
-                        }
-                    }
-                }
-            }
-        }
-    `;
     (httpUtils.get as jest.Mock).mockImplementation(() => ({
       workflow_runs: [
         {
@@ -56,7 +41,10 @@ describe("workflowRuns query:", () => {
       ],
     }));
 
-    const result = await execute(query, {});
+    const result = await execute(
+      getExampleQuery("workflow-runs-query-empty"),
+      {}
+    );
 
     expect(httpUtils.get).toHaveBeenCalledWith(
       "/workflow_runs.json?&mode=basic&limit=10000000&offset=0&listAllIds=false",
@@ -97,30 +85,14 @@ describe("workflowRuns query:", () => {
   });
 
   it("Called with order by", async () => {
-    const query = `
-        query TestQuery($unused: String) {
-            workflowRuns(input: {
-                orderBy: {
-                    startedAt: "ASC"
-                }
-            }) {
-                id
-                entityInputs {
-                    edges {
-                        node {
-                            fieldName
-                            inputEntityId
-                        }
-                    }
-                }
-            }
-        }
-    `;
     (httpUtils.get as jest.Mock).mockImplementation(() => ({
       workflow_runs: [],
     }));
 
-    const result = await execute(query, {});
+    const result = await execute(
+      getExampleQuery("workflow-runs-query-order-by"),
+      {}
+    );
 
     expect(httpUtils.get).toHaveBeenCalledWith(
       "/workflow_runs.json?&mode=basic&orderBy=createdAt&orderDir=ASC&limit=10000000&offset=0&listAllIds=false",
@@ -131,26 +103,8 @@ describe("workflowRuns query:", () => {
   });
 
   describe("validConsensusGenomes query", () => {
-    const query = `
-      query ValidConsensusGenomeWorkflowRunsQuery(
-        $workflowRunIds: [String]
-        $authenticityToken: String!
-      ) {
-        workflowRuns(
-          input: {
-            where: { id: { _in: $workflowRunIds } }
-            todoRemove: { authenticityToken: $authenticityToken }
-          }
-        ) {
-          id
-          ownerUserId
-          status
-        }
-      }
-    `;
-
     it("should call the correct rails endpoint", async () => {
-      await execute(query, {
+      await execute(getExampleQuery("workflow-runs-query-id-list"), {
         authenticityToken: "authtoken1234",
         workflowRunIds: ["1997", "2007"],
       });
@@ -161,7 +115,7 @@ describe("workflowRuns query:", () => {
           workflowRunIds: [1997, 2007],
         },
         expect.anything(),
-        expect.anything(),
+        expect.anything()
       );
     });
   });

--- a/tests/ZipLinkQuery.test.ts
+++ b/tests/ZipLinkQuery.test.ts
@@ -1,5 +1,5 @@
 import { ExecuteMeshFn } from "@graphql-mesh/runtime";
-import { getZipLinkExampleQuery } from "./utils/ExampleQueryFiles";
+import { getExampleQuery } from "./utils/ExampleQueryFiles";
 import { getMeshInstance } from "./utils/MeshInstance";
 
 import * as httpUtils from "../utils/httpUtils";
@@ -17,39 +17,39 @@ describe("ZipLink Query", () => {
     const mesh$ = await getMeshInstance();
     // Load ZipLink example query
     ({ execute } = mesh$);
-    query = getZipLinkExampleQuery();
+    query = getExampleQuery("zip-link-query");
   });
 
   describe("ZipLink with url", () => {
     const zipLinkWorkflowRunId = "mockZipLinkId";
-    const zipLinkUrl = "zip_link_url"
+    const zipLinkUrl = "zip_link_url";
 
     it("should give correct response", async () => {
-      (httpUtils.getFullResponse as jest.Mock).mockImplementation(() => (
-        {
-          status: 200,
-          url: zipLinkUrl,
-        }
-      ));
-      const result = await execute(query, { workflowRunId: zipLinkWorkflowRunId });
+      (httpUtils.getFullResponse as jest.Mock).mockImplementation(() => ({
+        status: 200,
+        url: zipLinkUrl,
+      }));
+      const result = await execute(query, {
+        workflowRunId: zipLinkWorkflowRunId,
+      });
       expect(result.data.ZipLink.url).toBe(zipLinkUrl);
     });
   });
 
   describe("ZipLink with error", () => {
     const errorZipLinkWorkflowRunId = "mockErrorZipLinkId";
-    const zipLinkError = "zip_link_error"
+    const zipLinkError = "zip_link_error";
 
     it("should give correct response", async () => {
-      (httpUtils.getFullResponse as jest.Mock).mockImplementation(() => (
-        {
-          status: 500,
-          url: null,
-          statusText: zipLinkError
-        }
-      ));
+      (httpUtils.getFullResponse as jest.Mock).mockImplementation(() => ({
+        status: 500,
+        url: null,
+        statusText: zipLinkError,
+      }));
 
-      const result = await execute(query, { workflowRunId: errorZipLinkWorkflowRunId });
+      const result = await execute(query, {
+        workflowRunId: errorZipLinkWorkflowRunId,
+      });
       expect(result.data.ZipLink.error).toBe(zipLinkError);
     });
   });

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -17,13 +17,6 @@ directive @globalOptions(sourceName: String, endpoint: String, operationHeaders:
 directive @httpOperation(path: String, operationSpecificHeaders: ObjMap, httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap) on FIELD_DEFINITION
 
 type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") {
-  appConfig(id: ID!): AppConfig
-  pathogenList(version: String): PathogenList!
-  project(id: Int!): Project!
-  sample(sampleId: Int!): Sample!
-  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
-  samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
-  user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
   node(
     """The ID of the object."""
     id: GlobalID!
@@ -57,6 +50,13 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   upstreamDatabasesAggregate(where: UpstreamDatabaseWhereClause = null): UpstreamDatabaseAggregate!
   contigsAggregate(where: ContigWhereClause = null): ContigAggregate!
   phylogeneticTreesAggregate(where: PhylogeneticTreeWhereClause = null): PhylogeneticTreeAggregate!
+  appConfig(id: ID!): AppConfig
+  pathogenList(version: String): PathogenList!
+  project(id: Int!): Project!
+  sample(sampleId: Int!): Sample!
+  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
+  samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
+  user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
   AmrDeprecatedResults(sampleId: String): AmrDeprecatedResults @httpOperation(path: "/samples/{args.sampleId}/amr.json", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   AmrWorkflowResults(workflowRunId: String): AmrWorkflowResults @httpOperation(path: "/workflow_runs/{args.workflowRunId}/results", httpMethod: GET)
   Background(snapshotLinkId: String): Background @httpOperation(path: "/pub/{args.snapshotLinkId}/backgrounds.json", httpMethod: GET)
@@ -80,7 +80,6 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
 }
 
 type Mutation {
-  createUser(archetypes: String, email: String!, institution: String, name: String, role: Int, segments: String, sendActivation: Boolean): CreateUserPayload!
   createFile(entityId: ID!, entityFieldName: String!, file: FileCreate!): File!
   uploadFile(entityId: ID!, entityFieldName: String!, file: FileUpload!, expiration: Int! = 3600): MultipartUploadResponse!
   markUploadComplete(fileId: ID!): File!
@@ -121,6 +120,7 @@ type Mutation {
   createPhylogeneticTree(input: PhylogeneticTreeCreateInput!): PhylogeneticTree!
   updatePhylogeneticTree(input: PhylogeneticTreeUpdateInput!, where: PhylogeneticTreeWhereClauseMutations!): [PhylogeneticTree!]!
   deletePhylogeneticTree(where: PhylogeneticTreeWhereClauseMutations!): [PhylogeneticTree!]!
+  createUser(archetypes: String, email: String!, institution: String, name: String, role: Int, segments: String, sendActivation: Boolean): CreateUserPayload!
   CreateBulkDownload(input: mutationInput_CreateBulkDownload_input_Input): JSON @httpOperation(path: "/bulk_download", httpMethod: POST)
   DeleteSamples(input: mutationInput_DeleteSamples_input_Input): DeleteSamples @httpOperation(path: "/samples/bulk_delete", httpMethod: POST)
   UpdateSampleNotes(sampleId: String, input: mutationInput_UpdateSampleNotes_input_Input): UpdateSampleNotes @httpOperation(path: "/samples/{args.sampleId}/save_metadata", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
@@ -128,371 +128,6 @@ type Mutation {
   KickoffWGSWorkflow(sampleId: String, input: mutationInput_KickoffWGSWorkflow_input_Input): [mutation_KickoffWGSWorkflow_items] @httpOperation(path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   KickoffAMRWorkflow(sampleId: String, input: mutationInput_KickoffAMRWorkflow_input_Input): [mutation_KickoffWGSWorkflow_items] @httpOperation(path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   UpdateMetadata(sampleId: String, input: mutationInput_UpdateMetadata_input_Input): UpdateMetadataReponse @httpOperation(path: "/samples/{args.sampleId}/save_metadata_v2", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
-}
-
-type AlignmentConfig {
-  createdAt: ISO8601DateTime!
-  indexDirSuffix: String
-  lineageVersion: String!
-  lineageVersionOld: Int
-  name: String
-  s3Accession2taxidPath: String
-  s3DeuterostomeDbPath: String
-  s3LineagePath: String
-  s3NrDbPath: String
-  s3NrLocDbPath: String
-  s3NtDbPath: String
-  s3NtInfoDbPath: String
-  s3NtLocDbPath: String
-  s3TaxonBlacklistPath: String
-  updatedAt: ISO8601DateTime!
-}
-
-input Annotation {
-  name: String!
-}
-
-type AppConfig {
-  key: String!
-  value: String!
-}
-
-"""
-Represents non-fractional signed whole numeric values. Since the value may
-exceed the size of a 32-bit integer, it's encoded as a string.
-"""
-scalar BigInt
-
-"""Autogenerated return type of CreateUser."""
-type CreateUserPayload {
-  archetypes: String
-  email: String
-  institution: String
-  name: String
-  role: Int
-  segments: String
-  sendActivation: Boolean
-}
-
-type DbSample {
-  alignmentConfigName: String
-  basespaceAccessToken: String
-  clientUpdatedAt: ISO8601DateTime
-  createdAt: ISO8601DateTime!
-  dagVars: String
-  doNotProcess: Boolean!
-  hostGenomeId: Int
-  hostGenomeName: String
-  id: Int!
-  initialWorkflow: String!
-  inputFiles: [InputFile!]!
-  maxInputFragments: Int
-  name: String
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  privateUntil: ISO8601DateTime
-  projectId: Int
-  s3Bowtie2IndexPath: String
-  s3PreloadResultPath: String
-  s3StarIndexPath: String
-  sampleNotes: String
-  status: String
-  subsample: Int
-  updatedAt: ISO8601DateTime!
-  uploadError: String
-  uploadedFromBasespace: Int!
-  useTaxonWhitelist: Boolean!
-  userId: Int!
-  webCommit: String
-}
-
-type DerivedSampleOutput {
-  hostGenomeName: String!
-  pipelineRun: PipelineRun
-  projectName: String!
-  summaryStats: SampleSummaryStats
-}
-
-type HostGenome {
-  createdAt: ISO8601DateTime!
-  defaultBackgroundId: Int
-  id: Int!
-  name: String!
-  s3Bowtie2IndexPath: String!
-  s3Minimap2IndexPath: String
-  s3StarIndexPath: String!
-  samplesCount: Int!
-  skipDeuteroFilter: Int!
-  taxaCategory: String!
-  updatedAt: ISO8601DateTime!
-  user: User
-  userId: Int
-}
-
-"""An ISO 8601-encoded datetime"""
-scalar ISO8601DateTime
-
-type InputFile {
-  createdAt: ISO8601DateTime!
-  id: Int!
-  name: String
-  parts: String
-  presignedUrl: String
-  sampleId: Int!
-  source: String
-  sourceType: String
-  updatedAt: ISO8601DateTime
-  uploadClient: String
-}
-
-type MngsRunInfo {
-  createdAt: ISO8601DateTime
-  finalized: Int
-  reportReady: Boolean
-  resultStatusDescription: String
-  totalRuntime: Int
-  withAssembly: Int
-}
-
-type Pathogen {
-  category: String
-  name: String
-  taxId: Int
-}
-
-type PathogenList {
-  citations: [String!]
-  createdAt: ISO8601DateTime
-  id: ID
-  name: String
-  pathogens: [Pathogen!]
-  updatedAt: ISO8601DateTime
-  version: String
-}
-
-type PipelineRun {
-  adjustedRemainingReads: Int
-  alertSent: Boolean!
-  alignmentConfig: AlignmentConfig
-  alignmentConfigId: Int
-  alignmentConfigName: String
-  assembled: Int
-  compressionRatio: Float
-  createdAt: ISO8601DateTime
-  dagVars: String
-  deprecated: Boolean
-  errorMessage: String
-  executedAt: ISO8601DateTime
-  finalized: Int
-  fractionSubsampled: Float
-  id: Int!
-  jobStatus: String
-  knownUserError: String
-  maxInputFragments: Int
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  pipelineVersion: String
-  qcPercent: Float
-  resultsFinalized: Int
-  s3OutputPrefix: String
-  sampleId: Int
-  sfnExecutionArn: String
-  subsample: Int
-  timeToFinalized: Int
-  timeToResultsFinalized: Int
-  totalErccReads: Int
-  totalReads: Int
-  truncated: Int
-  unmappedReads: Int
-  updatedAt: ISO8601DateTime!
-  useTaxonWhitelist: Boolean!
-  wdlVersion: String
-}
-
-type Project {
-  backgroundFlag: Int
-  createdAt: ISO8601DateTime!
-  creator: User
-  daysToKeepSamplePrivate: Int!
-  description: String
-  id: Int!
-  maxInputFragmentsDefault: Int
-  name: String!
-  publicAccess: Int!
-  samples: [Sample!]
-  subsampleDefault: Int
-  totalSampleCount: Int!
-  updatedAt: ISO8601DateTime!
-}
-
-type Sample implements EntityInterface & Node {
-  alignmentConfigName: String
-  basespaceAccessToken: String
-  createdAt: ISO8601DateTime
-  dagVars: String
-  defaultBackgroundId: Int
-  defaultPipelineRunId: Int
-  details: SampleDetails!
-  doNotProcess: Boolean!
-  editable: Boolean
-  hostGenome: HostGenome
-  hostGenomeId: Int
-  id: ID!
-  initialWorkflow: String!
-  maxInputFragments: Int
-  name: String!
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  pipelineRuns: [PipelineRun!]
-  privateUntil: ISO8601DateTime
-  project: Project
-  projectId: Int
-  public: Int!
-  s3Bowtie2IndexPath: String
-  s3PreloadResultPath: String
-  s3StarIndexPath: String
-  sampleDeletable: Boolean
-  sampleNotes: String
-  status: String
-  subsample: Int
-  updatedAt: ISO8601DateTime
-  uploadError: String
-  uploadedFromBasespace: Int
-  useTaxonWhitelist: Boolean!
-  user: User
-  userId: Int
-  webCommit: String
-  workflowRuns: [WorkflowRun!]
-  """The Globally Unique ID of this object"""
-  _id: GlobalID!
-  producingRunId: Int
-  ownerUserId: Int!
-  collectionId: Int!
-  sampleType: String!
-  waterControl: Boolean!
-  collectionDate: DateTime
-  collectionLocation: String!
-  description: String
-  hostTaxon(where: TaxonWhereClause = null): Taxon
-  sequencingReads(
-    where: SequencingReadWhereClause = null
-    """Returns the items in the list that come before the specified cursor."""
-    before: String = null
-    """Returns the items in the list that come after the specified cursor."""
-    after: String = null
-    """Returns the first n items from the list."""
-    first: Int = null
-    """Returns the items in the list that come after the specified cursor."""
-    last: Int = null
-  ): SequencingReadConnection!
-  sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
-  metadatas(
-    where: MetadatumWhereClause = null
-    """Returns the items in the list that come before the specified cursor."""
-    before: String = null
-    """Returns the items in the list that come after the specified cursor."""
-    after: String = null
-    """Returns the first n items from the list."""
-    first: Int = null
-    """Returns the items in the list that come after the specified cursor."""
-    last: Int = null
-  ): MetadatumConnection!
-  metadatasAggregate(where: MetadatumWhereClause = null): MetadatumAggregate
-}
-
-type SampleDetails {
-  dbSample: DbSample
-  derivedSampleOutput: DerivedSampleOutput
-  metadata: SampleMetadata
-  mngsRunInfo: MngsRunInfo
-  uploader: SampleUploader!
-  workflowRunsCountByWorkflow: String
-}
-
-type SampleList {
-  sampleIds: [Int!]
-  samples: [Sample!]!
-}
-
-type SampleMetadata {
-  collectionDate: String
-  collectionLocationV2: String
-  nucleotideType: String
-  sampleType: String
-  waterControl: String
-  metadata: [query_SampleMetadata_metadata_items]
-  additional_info: query_SampleMetadata_additional_info
-}
-
-type SampleReadsStats {
-  initialReads: Int
-  name: String
-  pipelineVersion: String
-  sampleId: ID!
-  steps: [SampleSteps!]
-  wdlVersion: String
-}
-
-type SampleReadsStatsList {
-  sampleReadsStats: [SampleReadsStats!]!
-}
-
-type SampleSteps {
-  name: String
-  readsAfter: Int
-}
-
-type SampleSummaryStats {
-  adjustedRemainingReads: Int
-  compressionRatio: Float
-  insertSizeMean: Float
-  insertSizeStandardDeviation: Float
-  lastProcessedAt: ISO8601DateTime
-  percentRemaining: Float
-  qcPercent: Float
-  readsAfterCzidDedup: Int
-  readsAfterPriceseq: Int
-  readsAfterStar: Int
-  readsAfterTrimmomatic: Int
-  unmappedReads: Int
-}
-
-type SampleUploader {
-  id: Int!
-  name: String
-}
-
-type User {
-  archetypes: String!
-  createdByUserId: BigInt!
-  email: String!
-  id: ID!
-  institution: String!
-  name: String!
-  role: Int!
-  segments: String!
-}
-
-type WorkflowRun {
-  cachedResults: String
-  createdAt: ISO8601DateTime!
-  deprecated: Boolean!
-  errorMessage: String
-  executedAt: ISO8601DateTime
-  inputsJson: String
-  rerunFrom: Int
-  s3OutputPrefix: String
-  sample: Sample
-  sampleId: Int
-  sfnExecutionArn: String
-  status: String!
-  timeToFinalized: Int
-  updatedAt: ISO8601DateTime!
-  wdlVersion: String
-  workflow: String!
 }
 
 enum AlignmentTool {
@@ -1522,6 +1157,82 @@ input ReferenceGenomeWhereClauseMutations {
   id: UUIDComparators
 }
 
+type Sample implements EntityInterface & Node {
+  """The Globally Unique ID of this object"""
+  _id: GlobalID!
+  id: ID!
+  producingRunId: Int
+  ownerUserId: Int!
+  collectionId: Int!
+  name: String!
+  sampleType: String!
+  waterControl: Boolean!
+  collectionDate: DateTime
+  collectionLocation: String!
+  description: String
+  hostTaxon(where: TaxonWhereClause = null): Taxon
+  sequencingReads(
+    where: SequencingReadWhereClause = null
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+    """Returns the first n items from the list."""
+    first: Int = null
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): SequencingReadConnection!
+  sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
+  metadatas(
+    where: MetadatumWhereClause = null
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+    """Returns the first n items from the list."""
+    first: Int = null
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MetadatumConnection!
+  metadatasAggregate(where: MetadatumWhereClause = null): MetadatumAggregate
+  alignmentConfigName: String
+  basespaceAccessToken: String
+  createdAt: ISO8601DateTime
+  dagVars: String
+  defaultBackgroundId: Int
+  defaultPipelineRunId: Int
+  details: SampleDetails!
+  doNotProcess: Boolean!
+  editable: Boolean
+  hostGenome: HostGenome
+  hostGenomeId: Int
+  initialWorkflow: String!
+  maxInputFragments: Int
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  pipelineRuns: [PipelineRun!]
+  privateUntil: ISO8601DateTime
+  project: Project
+  projectId: Int
+  public: Int!
+  s3Bowtie2IndexPath: String
+  s3PreloadResultPath: String
+  s3StarIndexPath: String
+  sampleDeletable: Boolean
+  sampleNotes: String
+  status: String
+  subsample: Int
+  updatedAt: ISO8601DateTime
+  uploadError: String
+  uploadedFromBasespace: Int
+  useTaxonWhitelist: Boolean!
+  user: User
+  userId: Int
+  webCommit: String
+  workflowRuns: [WorkflowRun!]
+}
+
 type SampleAggregate {
   aggregate: SampleAggregateFunctions
 }
@@ -2256,6 +1967,295 @@ input UpstreamDatabaseWhereClause {
 
 input UpstreamDatabaseWhereClauseMutations {
   id: UUIDComparators
+}
+
+type AlignmentConfig {
+  createdAt: ISO8601DateTime!
+  indexDirSuffix: String
+  lineageVersion: String!
+  lineageVersionOld: Int
+  name: String
+  s3Accession2taxidPath: String
+  s3DeuterostomeDbPath: String
+  s3LineagePath: String
+  s3NrDbPath: String
+  s3NrLocDbPath: String
+  s3NtDbPath: String
+  s3NtInfoDbPath: String
+  s3NtLocDbPath: String
+  s3TaxonBlacklistPath: String
+  updatedAt: ISO8601DateTime!
+}
+
+input Annotation {
+  name: String!
+}
+
+type AppConfig {
+  key: String!
+  value: String!
+}
+
+"""
+Represents non-fractional signed whole numeric values. Since the value may
+exceed the size of a 32-bit integer, it's encoded as a string.
+"""
+scalar BigInt
+
+"""Autogenerated return type of CreateUser."""
+type CreateUserPayload {
+  archetypes: String
+  email: String
+  institution: String
+  name: String
+  role: Int
+  segments: String
+  sendActivation: Boolean
+}
+
+type DbSample {
+  alignmentConfigName: String
+  basespaceAccessToken: String
+  clientUpdatedAt: ISO8601DateTime
+  createdAt: ISO8601DateTime!
+  dagVars: String
+  doNotProcess: Boolean!
+  hostGenomeId: Int
+  hostGenomeName: String
+  id: Int!
+  initialWorkflow: String!
+  inputFiles: [InputFile!]!
+  maxInputFragments: Int
+  name: String
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  privateUntil: ISO8601DateTime
+  projectId: Int
+  s3Bowtie2IndexPath: String
+  s3PreloadResultPath: String
+  s3StarIndexPath: String
+  sampleNotes: String
+  status: String
+  subsample: Int
+  updatedAt: ISO8601DateTime!
+  uploadError: String
+  uploadedFromBasespace: Int!
+  useTaxonWhitelist: Boolean!
+  userId: Int!
+  webCommit: String
+}
+
+type DerivedSampleOutput {
+  hostGenomeName: String!
+  pipelineRun: PipelineRun
+  projectName: String!
+  summaryStats: SampleSummaryStats
+}
+
+type HostGenome {
+  createdAt: ISO8601DateTime!
+  defaultBackgroundId: Int
+  id: Int!
+  name: String!
+  s3Bowtie2IndexPath: String!
+  s3Minimap2IndexPath: String
+  s3StarIndexPath: String!
+  samplesCount: Int!
+  skipDeuteroFilter: Int!
+  taxaCategory: String!
+  updatedAt: ISO8601DateTime!
+  user: User
+  userId: Int
+}
+
+"""An ISO 8601-encoded datetime"""
+scalar ISO8601DateTime
+
+type InputFile {
+  createdAt: ISO8601DateTime!
+  id: Int!
+  name: String
+  parts: String
+  presignedUrl: String
+  sampleId: Int!
+  source: String
+  sourceType: String
+  updatedAt: ISO8601DateTime
+  uploadClient: String
+}
+
+type MngsRunInfo {
+  createdAt: ISO8601DateTime
+  finalized: Int
+  reportReady: Boolean
+  resultStatusDescription: String
+  totalRuntime: Int
+  withAssembly: Int
+}
+
+type Pathogen {
+  category: String
+  name: String
+  taxId: Int
+}
+
+type PathogenList {
+  citations: [String!]
+  createdAt: ISO8601DateTime
+  id: ID
+  name: String
+  pathogens: [Pathogen!]
+  updatedAt: ISO8601DateTime
+  version: String
+}
+
+type PipelineRun {
+  adjustedRemainingReads: Int
+  alertSent: Boolean!
+  alignmentConfig: AlignmentConfig
+  alignmentConfigId: Int
+  alignmentConfigName: String
+  assembled: Int
+  compressionRatio: Float
+  createdAt: ISO8601DateTime
+  dagVars: String
+  deprecated: Boolean
+  errorMessage: String
+  executedAt: ISO8601DateTime
+  finalized: Int
+  fractionSubsampled: Float
+  id: Int!
+  jobStatus: String
+  knownUserError: String
+  maxInputFragments: Int
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  pipelineVersion: String
+  qcPercent: Float
+  resultsFinalized: Int
+  s3OutputPrefix: String
+  sampleId: Int
+  sfnExecutionArn: String
+  subsample: Int
+  timeToFinalized: Int
+  timeToResultsFinalized: Int
+  totalErccReads: Int
+  totalReads: Int
+  truncated: Int
+  unmappedReads: Int
+  updatedAt: ISO8601DateTime!
+  useTaxonWhitelist: Boolean!
+  wdlVersion: String
+}
+
+type Project {
+  backgroundFlag: Int
+  createdAt: ISO8601DateTime!
+  creator: User
+  daysToKeepSamplePrivate: Int!
+  description: String
+  id: Int!
+  maxInputFragmentsDefault: Int
+  name: String!
+  publicAccess: Int!
+  samples: [Sample!]
+  subsampleDefault: Int
+  totalSampleCount: Int!
+  updatedAt: ISO8601DateTime!
+}
+
+type SampleDetails {
+  dbSample: DbSample
+  derivedSampleOutput: DerivedSampleOutput
+  metadata: SampleMetadata
+  mngsRunInfo: MngsRunInfo
+  uploader: SampleUploader!
+  workflowRunsCountByWorkflow: String
+}
+
+type SampleList {
+  sampleIds: [Int!]
+  samples: [Sample!]!
+}
+
+type SampleMetadata {
+  collectionDate: String
+  collectionLocationV2: String
+  nucleotideType: String
+  sampleType: String
+  waterControl: String
+  metadata: [query_SampleMetadata_metadata_items]
+  additional_info: query_SampleMetadata_additional_info
+}
+
+type SampleReadsStats {
+  initialReads: Int
+  name: String
+  pipelineVersion: String
+  sampleId: ID!
+  steps: [SampleSteps!]
+  wdlVersion: String
+}
+
+type SampleReadsStatsList {
+  sampleReadsStats: [SampleReadsStats!]!
+}
+
+type SampleSteps {
+  name: String
+  readsAfter: Int
+}
+
+type SampleSummaryStats {
+  adjustedRemainingReads: Int
+  compressionRatio: Float
+  insertSizeMean: Float
+  insertSizeStandardDeviation: Float
+  lastProcessedAt: ISO8601DateTime
+  percentRemaining: Float
+  qcPercent: Float
+  readsAfterCzidDedup: Int
+  readsAfterPriceseq: Int
+  readsAfterStar: Int
+  readsAfterTrimmomatic: Int
+  unmappedReads: Int
+}
+
+type SampleUploader {
+  id: Int!
+  name: String
+}
+
+type User {
+  archetypes: String!
+  createdByUserId: BigInt!
+  email: String!
+  id: ID!
+  institution: String!
+  name: String!
+  role: Int!
+  segments: String!
+}
+
+type WorkflowRun {
+  cachedResults: String
+  createdAt: ISO8601DateTime!
+  deprecated: Boolean!
+  errorMessage: String
+  executedAt: ISO8601DateTime
+  inputsJson: String
+  rerunFrom: Int
+  s3OutputPrefix: String
+  sample: Sample
+  sampleId: Int
+  sfnExecutionArn: String
+  status: String!
+  timeToFinalized: Int
+  updatedAt: ISO8601DateTime!
+  wdlVersion: String
+  workflow: String!
 }
 
 type AmrDeprecatedResults {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -17,6 +17,13 @@ directive @globalOptions(sourceName: String, endpoint: String, operationHeaders:
 directive @httpOperation(path: String, operationSpecificHeaders: ObjMap, httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap) on FIELD_DEFINITION
 
 type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") {
+  appConfig(id: ID!): AppConfig
+  pathogenList(version: String): PathogenList!
+  project(id: Int!): Project!
+  sample(sampleId: Int!): Sample!
+  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
+  samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
+  user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
   node(
     """The ID of the object."""
     id: GlobalID!
@@ -27,12 +34,12 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   ): [Node!]!
   files(where: FileWhereClause = null): [File!]!
   samples(input: queryInput_samples_input_Input): [query_samples_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
-  sequencingReads(where: SequencingReadWhereClause = null): [SequencingRead!]!
+  sequencingReads(input: queryInput_sequencingReads_input_Input): [query_sequencingReads_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   genomicRanges(where: GenomicRangeWhereClause = null): [GenomicRange!]!
   referenceGenomes(where: ReferenceGenomeWhereClause = null): [ReferenceGenome!]!
   sequenceAlignmentIndices(where: SequenceAlignmentIndexWhereClause = null): [SequenceAlignmentIndex!]!
   metadatas(where: MetadatumWhereClause = null): [Metadatum!]!
-  consensusGenomes(where: ConsensusGenomeWhereClause = null): [ConsensusGenome!]!
+  consensusGenomes(input: queryInput_consensusGenomes_input_Input): [query_consensusGenomes_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   metricsConsensusGenomes(where: MetricConsensusGenomeWhereClause = null): [MetricConsensusGenome!]!
   taxa(where: TaxonWhereClause = null): [Taxon!]!
   upstreamDatabases(where: UpstreamDatabaseWhereClause = null): [UpstreamDatabase!]!
@@ -50,19 +57,11 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   upstreamDatabasesAggregate(where: UpstreamDatabaseWhereClause = null): UpstreamDatabaseAggregate!
   contigsAggregate(where: ContigWhereClause = null): ContigAggregate!
   phylogeneticTreesAggregate(where: PhylogeneticTreeWhereClause = null): PhylogeneticTreeAggregate!
-  appConfig(id: ID!): AppConfig
-  pathogenList(version: String): PathogenList!
-  project(id: Int!): Project!
-  sample(sampleId: Int!): Sample!
-  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
-  samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
-  user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
   AmrDeprecatedResults(sampleId: String): AmrDeprecatedResults @httpOperation(path: "/samples/{args.sampleId}/amr.json", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   AmrWorkflowResults(workflowRunId: String): AmrWorkflowResults @httpOperation(path: "/workflow_runs/{args.workflowRunId}/results", httpMethod: GET)
   Background(snapshotLinkId: String): Background @httpOperation(path: "/pub/{args.snapshotLinkId}/backgrounds.json", httpMethod: GET)
   BulkDownloadDetails(bulkDownloadId: String): BulkDownloadDetails @httpOperation(path: "/bulk_downloads/{args.bulkDownloadId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   BulkDownloadCGOverview(input: queryInput_BulkDownloadCGOverview_input_Input): ConsensusGenomeOverviewRows @httpOperation(path: "/bulk_downloads", httpMethod: POST)
-  consensusGenomes(input: queryInput_consensusGenomes_input_Input): [query_consensusGenomes_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   ConsensusGenomeWorkflowResults(workflowRunId: String): ConsensusGenomeWorkflowResults @httpOperation(path: "/workflow_runs/{args.workflowRunId}/results", httpMethod: GET)
   CoverageVizSummary(snapshotLinkId: String, sampleId: String): [query_CoverageVizSummary_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/coverage_viz_summary", httpMethod: GET)
   MetadataFields(snapshotLinkId: String, input: queryInput_MetadataFields_input_Input): [query_MetadataFields_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/metadata_fields", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
@@ -71,8 +70,6 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   Pathogens(snapshotLinkId: String, sampleId: String, workflowVersionId: String): [query_Pathogens_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   PersistedBackground(projectId: String): PersistedBackground @httpOperation(path: "/persisted_backgrounds/{args.projectId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   PipelineData(sampleId: String, workflowVersionId: String): PipelineData @httpOperation(path: "/samples/{args.sampleId}/pipeline_viz/{args.workflowVersionId}.json", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
-  samples(input: queryInput_samples_input_Input): [query_samples_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
-  sequencingReads(input: queryInput_sequencingReads_input_Input): [query_sequencingReads_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   Taxons(snapshotLinkId: String, sampleId: String, workflowVersionId: String): [query_Taxons_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   TaxonDist(backgroundId: String, taxonId: String): TaxonDist @httpOperation(path: "/backgrounds/{args.backgroundId}/show_taxon_dist.json?taxid={args.taxonId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   UserBlastAnnotations(sampleId: String, workflowVersionId: String): [query_UserBlastAnnotations_items] @httpOperation(path: "/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
@@ -83,6 +80,7 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
 }
 
 type Mutation {
+  createUser(archetypes: String, email: String!, institution: String, name: String, role: Int, segments: String, sendActivation: Boolean): CreateUserPayload!
   createFile(entityId: ID!, entityFieldName: String!, file: FileCreate!): File!
   uploadFile(entityId: ID!, entityFieldName: String!, file: FileUpload!, expiration: Int! = 3600): MultipartUploadResponse!
   markUploadComplete(fileId: ID!): File!
@@ -123,7 +121,6 @@ type Mutation {
   createPhylogeneticTree(input: PhylogeneticTreeCreateInput!): PhylogeneticTree!
   updatePhylogeneticTree(input: PhylogeneticTreeUpdateInput!, where: PhylogeneticTreeWhereClauseMutations!): [PhylogeneticTree!]!
   deletePhylogeneticTree(where: PhylogeneticTreeWhereClauseMutations!): [PhylogeneticTree!]!
-  createUser(archetypes: String, email: String!, institution: String, name: String, role: Int, segments: String, sendActivation: Boolean): CreateUserPayload!
   CreateBulkDownload(input: mutationInput_CreateBulkDownload_input_Input): JSON @httpOperation(path: "/bulk_download", httpMethod: POST)
   DeleteSamples(input: mutationInput_DeleteSamples_input_Input): DeleteSamples @httpOperation(path: "/samples/bulk_delete", httpMethod: POST)
   UpdateSampleNotes(sampleId: String, input: mutationInput_UpdateSampleNotes_input_Input): UpdateSampleNotes @httpOperation(path: "/samples/{args.sampleId}/save_metadata", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
@@ -131,6 +128,371 @@ type Mutation {
   KickoffWGSWorkflow(sampleId: String, input: mutationInput_KickoffWGSWorkflow_input_Input): [mutation_KickoffWGSWorkflow_items] @httpOperation(path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   KickoffAMRWorkflow(sampleId: String, input: mutationInput_KickoffAMRWorkflow_input_Input): [mutation_KickoffWGSWorkflow_items] @httpOperation(path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   UpdateMetadata(sampleId: String, input: mutationInput_UpdateMetadata_input_Input): UpdateMetadataReponse @httpOperation(path: "/samples/{args.sampleId}/save_metadata_v2", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
+}
+
+type AlignmentConfig {
+  createdAt: ISO8601DateTime!
+  indexDirSuffix: String
+  lineageVersion: String!
+  lineageVersionOld: Int
+  name: String
+  s3Accession2taxidPath: String
+  s3DeuterostomeDbPath: String
+  s3LineagePath: String
+  s3NrDbPath: String
+  s3NrLocDbPath: String
+  s3NtDbPath: String
+  s3NtInfoDbPath: String
+  s3NtLocDbPath: String
+  s3TaxonBlacklistPath: String
+  updatedAt: ISO8601DateTime!
+}
+
+input Annotation {
+  name: String!
+}
+
+type AppConfig {
+  key: String!
+  value: String!
+}
+
+"""
+Represents non-fractional signed whole numeric values. Since the value may
+exceed the size of a 32-bit integer, it's encoded as a string.
+"""
+scalar BigInt
+
+"""Autogenerated return type of CreateUser."""
+type CreateUserPayload {
+  archetypes: String
+  email: String
+  institution: String
+  name: String
+  role: Int
+  segments: String
+  sendActivation: Boolean
+}
+
+type DbSample {
+  alignmentConfigName: String
+  basespaceAccessToken: String
+  clientUpdatedAt: ISO8601DateTime
+  createdAt: ISO8601DateTime!
+  dagVars: String
+  doNotProcess: Boolean!
+  hostGenomeId: Int
+  hostGenomeName: String
+  id: Int!
+  initialWorkflow: String!
+  inputFiles: [InputFile!]!
+  maxInputFragments: Int
+  name: String
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  privateUntil: ISO8601DateTime
+  projectId: Int
+  s3Bowtie2IndexPath: String
+  s3PreloadResultPath: String
+  s3StarIndexPath: String
+  sampleNotes: String
+  status: String
+  subsample: Int
+  updatedAt: ISO8601DateTime!
+  uploadError: String
+  uploadedFromBasespace: Int!
+  useTaxonWhitelist: Boolean!
+  userId: Int!
+  webCommit: String
+}
+
+type DerivedSampleOutput {
+  hostGenomeName: String!
+  pipelineRun: PipelineRun
+  projectName: String!
+  summaryStats: SampleSummaryStats
+}
+
+type HostGenome {
+  createdAt: ISO8601DateTime!
+  defaultBackgroundId: Int
+  id: Int!
+  name: String!
+  s3Bowtie2IndexPath: String!
+  s3Minimap2IndexPath: String
+  s3StarIndexPath: String!
+  samplesCount: Int!
+  skipDeuteroFilter: Int!
+  taxaCategory: String!
+  updatedAt: ISO8601DateTime!
+  user: User
+  userId: Int
+}
+
+"""An ISO 8601-encoded datetime"""
+scalar ISO8601DateTime
+
+type InputFile {
+  createdAt: ISO8601DateTime!
+  id: Int!
+  name: String
+  parts: String
+  presignedUrl: String
+  sampleId: Int!
+  source: String
+  sourceType: String
+  updatedAt: ISO8601DateTime
+  uploadClient: String
+}
+
+type MngsRunInfo {
+  createdAt: ISO8601DateTime
+  finalized: Int
+  reportReady: Boolean
+  resultStatusDescription: String
+  totalRuntime: Int
+  withAssembly: Int
+}
+
+type Pathogen {
+  category: String
+  name: String
+  taxId: Int
+}
+
+type PathogenList {
+  citations: [String!]
+  createdAt: ISO8601DateTime
+  id: ID
+  name: String
+  pathogens: [Pathogen!]
+  updatedAt: ISO8601DateTime
+  version: String
+}
+
+type PipelineRun {
+  adjustedRemainingReads: Int
+  alertSent: Boolean!
+  alignmentConfig: AlignmentConfig
+  alignmentConfigId: Int
+  alignmentConfigName: String
+  assembled: Int
+  compressionRatio: Float
+  createdAt: ISO8601DateTime
+  dagVars: String
+  deprecated: Boolean
+  errorMessage: String
+  executedAt: ISO8601DateTime
+  finalized: Int
+  fractionSubsampled: Float
+  id: Int!
+  jobStatus: String
+  knownUserError: String
+  maxInputFragments: Int
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  pipelineVersion: String
+  qcPercent: Float
+  resultsFinalized: Int
+  s3OutputPrefix: String
+  sampleId: Int
+  sfnExecutionArn: String
+  subsample: Int
+  timeToFinalized: Int
+  timeToResultsFinalized: Int
+  totalErccReads: Int
+  totalReads: Int
+  truncated: Int
+  unmappedReads: Int
+  updatedAt: ISO8601DateTime!
+  useTaxonWhitelist: Boolean!
+  wdlVersion: String
+}
+
+type Project {
+  backgroundFlag: Int
+  createdAt: ISO8601DateTime!
+  creator: User
+  daysToKeepSamplePrivate: Int!
+  description: String
+  id: Int!
+  maxInputFragmentsDefault: Int
+  name: String!
+  publicAccess: Int!
+  samples: [Sample!]
+  subsampleDefault: Int
+  totalSampleCount: Int!
+  updatedAt: ISO8601DateTime!
+}
+
+type Sample implements EntityInterface & Node {
+  alignmentConfigName: String
+  basespaceAccessToken: String
+  createdAt: ISO8601DateTime
+  dagVars: String
+  defaultBackgroundId: Int
+  defaultPipelineRunId: Int
+  details: SampleDetails!
+  doNotProcess: Boolean!
+  editable: Boolean
+  hostGenome: HostGenome
+  hostGenomeId: Int
+  id: ID!
+  initialWorkflow: String!
+  maxInputFragments: Int
+  name: String!
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  pipelineRuns: [PipelineRun!]
+  privateUntil: ISO8601DateTime
+  project: Project
+  projectId: Int
+  public: Int!
+  s3Bowtie2IndexPath: String
+  s3PreloadResultPath: String
+  s3StarIndexPath: String
+  sampleDeletable: Boolean
+  sampleNotes: String
+  status: String
+  subsample: Int
+  updatedAt: ISO8601DateTime
+  uploadError: String
+  uploadedFromBasespace: Int
+  useTaxonWhitelist: Boolean!
+  user: User
+  userId: Int
+  webCommit: String
+  workflowRuns: [WorkflowRun!]
+  """The Globally Unique ID of this object"""
+  _id: GlobalID!
+  producingRunId: Int
+  ownerUserId: Int!
+  collectionId: Int!
+  sampleType: String!
+  waterControl: Boolean!
+  collectionDate: DateTime
+  collectionLocation: String!
+  description: String
+  hostTaxon(where: TaxonWhereClause = null): Taxon
+  sequencingReads(
+    where: SequencingReadWhereClause = null
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+    """Returns the first n items from the list."""
+    first: Int = null
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): SequencingReadConnection!
+  sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
+  metadatas(
+    where: MetadatumWhereClause = null
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+    """Returns the first n items from the list."""
+    first: Int = null
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MetadatumConnection!
+  metadatasAggregate(where: MetadatumWhereClause = null): MetadatumAggregate
+}
+
+type SampleDetails {
+  dbSample: DbSample
+  derivedSampleOutput: DerivedSampleOutput
+  metadata: SampleMetadata
+  mngsRunInfo: MngsRunInfo
+  uploader: SampleUploader!
+  workflowRunsCountByWorkflow: String
+}
+
+type SampleList {
+  sampleIds: [Int!]
+  samples: [Sample!]!
+}
+
+type SampleMetadata {
+  collectionDate: String
+  collectionLocationV2: String
+  nucleotideType: String
+  sampleType: String
+  waterControl: String
+  metadata: [query_SampleMetadata_metadata_items]
+  additional_info: query_SampleMetadata_additional_info
+}
+
+type SampleReadsStats {
+  initialReads: Int
+  name: String
+  pipelineVersion: String
+  sampleId: ID!
+  steps: [SampleSteps!]
+  wdlVersion: String
+}
+
+type SampleReadsStatsList {
+  sampleReadsStats: [SampleReadsStats!]!
+}
+
+type SampleSteps {
+  name: String
+  readsAfter: Int
+}
+
+type SampleSummaryStats {
+  adjustedRemainingReads: Int
+  compressionRatio: Float
+  insertSizeMean: Float
+  insertSizeStandardDeviation: Float
+  lastProcessedAt: ISO8601DateTime
+  percentRemaining: Float
+  qcPercent: Float
+  readsAfterCzidDedup: Int
+  readsAfterPriceseq: Int
+  readsAfterStar: Int
+  readsAfterTrimmomatic: Int
+  unmappedReads: Int
+}
+
+type SampleUploader {
+  id: Int!
+  name: String
+}
+
+type User {
+  archetypes: String!
+  createdByUserId: BigInt!
+  email: String!
+  id: ID!
+  institution: String!
+  name: String!
+  role: Int!
+  segments: String!
+}
+
+type WorkflowRun {
+  cachedResults: String
+  createdAt: ISO8601DateTime!
+  deprecated: Boolean!
+  errorMessage: String
+  executedAt: ISO8601DateTime
+  inputsJson: String
+  rerunFrom: Int
+  s3OutputPrefix: String
+  sample: Sample
+  sampleId: Int
+  sfnExecutionArn: String
+  status: String!
+  timeToFinalized: Int
+  updatedAt: ISO8601DateTime!
+  wdlVersion: String
+  workflow: String!
 }
 
 enum AlignmentTool {
@@ -1160,82 +1522,6 @@ input ReferenceGenomeWhereClauseMutations {
   id: UUIDComparators
 }
 
-type Sample implements EntityInterface & Node {
-  """The Globally Unique ID of this object"""
-  _id: GlobalID!
-  id: ID!
-  producingRunId: Int
-  ownerUserId: Int!
-  collectionId: Int!
-  name: String!
-  sampleType: String!
-  waterControl: Boolean!
-  collectionDate: DateTime
-  collectionLocation: String!
-  description: String
-  hostTaxon(where: TaxonWhereClause = null): Taxon
-  sequencingReads(
-    where: SequencingReadWhereClause = null
-    """Returns the items in the list that come before the specified cursor."""
-    before: String = null
-    """Returns the items in the list that come after the specified cursor."""
-    after: String = null
-    """Returns the first n items from the list."""
-    first: Int = null
-    """Returns the items in the list that come after the specified cursor."""
-    last: Int = null
-  ): SequencingReadConnection!
-  sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
-  metadatas(
-    where: MetadatumWhereClause = null
-    """Returns the items in the list that come before the specified cursor."""
-    before: String = null
-    """Returns the items in the list that come after the specified cursor."""
-    after: String = null
-    """Returns the first n items from the list."""
-    first: Int = null
-    """Returns the items in the list that come after the specified cursor."""
-    last: Int = null
-  ): MetadatumConnection!
-  metadatasAggregate(where: MetadatumWhereClause = null): MetadatumAggregate
-  alignmentConfigName: String
-  basespaceAccessToken: String
-  createdAt: ISO8601DateTime
-  dagVars: String
-  defaultBackgroundId: Int
-  defaultPipelineRunId: Int
-  details: SampleDetails!
-  doNotProcess: Boolean!
-  editable: Boolean
-  hostGenome: HostGenome
-  hostGenomeId: Int
-  initialWorkflow: String!
-  maxInputFragments: Int
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  pipelineRuns: [PipelineRun!]
-  privateUntil: ISO8601DateTime
-  project: Project
-  projectId: Int
-  public: Int!
-  s3Bowtie2IndexPath: String
-  s3PreloadResultPath: String
-  s3StarIndexPath: String
-  sampleDeletable: Boolean
-  sampleNotes: String
-  status: String
-  subsample: Int
-  updatedAt: ISO8601DateTime
-  uploadError: String
-  uploadedFromBasespace: Int
-  useTaxonWhitelist: Boolean!
-  user: User
-  userId: Int
-  webCommit: String
-  workflowRuns: [WorkflowRun!]
-}
-
 type SampleAggregate {
   aggregate: SampleAggregateFunctions
 }
@@ -1970,295 +2256,6 @@ input UpstreamDatabaseWhereClause {
 
 input UpstreamDatabaseWhereClauseMutations {
   id: UUIDComparators
-}
-
-type AlignmentConfig {
-  createdAt: ISO8601DateTime!
-  indexDirSuffix: String
-  lineageVersion: String!
-  lineageVersionOld: Int
-  name: String
-  s3Accession2taxidPath: String
-  s3DeuterostomeDbPath: String
-  s3LineagePath: String
-  s3NrDbPath: String
-  s3NrLocDbPath: String
-  s3NtDbPath: String
-  s3NtInfoDbPath: String
-  s3NtLocDbPath: String
-  s3TaxonBlacklistPath: String
-  updatedAt: ISO8601DateTime!
-}
-
-input Annotation {
-  name: String!
-}
-
-type AppConfig {
-  key: String!
-  value: String!
-}
-
-"""
-Represents non-fractional signed whole numeric values. Since the value may
-exceed the size of a 32-bit integer, it's encoded as a string.
-"""
-scalar BigInt
-
-"""Autogenerated return type of CreateUser."""
-type CreateUserPayload {
-  archetypes: String
-  email: String
-  institution: String
-  name: String
-  role: Int
-  segments: String
-  sendActivation: Boolean
-}
-
-type DbSample {
-  alignmentConfigName: String
-  basespaceAccessToken: String
-  clientUpdatedAt: ISO8601DateTime
-  createdAt: ISO8601DateTime!
-  dagVars: String
-  doNotProcess: Boolean!
-  hostGenomeId: Int
-  hostGenomeName: String
-  id: Int!
-  initialWorkflow: String!
-  inputFiles: [InputFile!]!
-  maxInputFragments: Int
-  name: String
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  privateUntil: ISO8601DateTime
-  projectId: Int
-  s3Bowtie2IndexPath: String
-  s3PreloadResultPath: String
-  s3StarIndexPath: String
-  sampleNotes: String
-  status: String
-  subsample: Int
-  updatedAt: ISO8601DateTime!
-  uploadError: String
-  uploadedFromBasespace: Int!
-  useTaxonWhitelist: Boolean!
-  userId: Int!
-  webCommit: String
-}
-
-type DerivedSampleOutput {
-  hostGenomeName: String!
-  pipelineRun: PipelineRun
-  projectName: String!
-  summaryStats: SampleSummaryStats
-}
-
-type HostGenome {
-  createdAt: ISO8601DateTime!
-  defaultBackgroundId: Int
-  id: Int!
-  name: String!
-  s3Bowtie2IndexPath: String!
-  s3Minimap2IndexPath: String
-  s3StarIndexPath: String!
-  samplesCount: Int!
-  skipDeuteroFilter: Int!
-  taxaCategory: String!
-  updatedAt: ISO8601DateTime!
-  user: User
-  userId: Int
-}
-
-"""An ISO 8601-encoded datetime"""
-scalar ISO8601DateTime
-
-type InputFile {
-  createdAt: ISO8601DateTime!
-  id: Int!
-  name: String
-  parts: String
-  presignedUrl: String
-  sampleId: Int!
-  source: String
-  sourceType: String
-  updatedAt: ISO8601DateTime
-  uploadClient: String
-}
-
-type MngsRunInfo {
-  createdAt: ISO8601DateTime
-  finalized: Int
-  reportReady: Boolean
-  resultStatusDescription: String
-  totalRuntime: Int
-  withAssembly: Int
-}
-
-type Pathogen {
-  category: String
-  name: String
-  taxId: Int
-}
-
-type PathogenList {
-  citations: [String!]
-  createdAt: ISO8601DateTime
-  id: ID
-  name: String
-  pathogens: [Pathogen!]
-  updatedAt: ISO8601DateTime
-  version: String
-}
-
-type PipelineRun {
-  adjustedRemainingReads: Int
-  alertSent: Boolean!
-  alignmentConfig: AlignmentConfig
-  alignmentConfigId: Int
-  alignmentConfigName: String
-  assembled: Int
-  compressionRatio: Float
-  createdAt: ISO8601DateTime
-  dagVars: String
-  deprecated: Boolean
-  errorMessage: String
-  executedAt: ISO8601DateTime
-  finalized: Int
-  fractionSubsampled: Float
-  id: Int!
-  jobStatus: String
-  knownUserError: String
-  maxInputFragments: Int
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  pipelineVersion: String
-  qcPercent: Float
-  resultsFinalized: Int
-  s3OutputPrefix: String
-  sampleId: Int
-  sfnExecutionArn: String
-  subsample: Int
-  timeToFinalized: Int
-  timeToResultsFinalized: Int
-  totalErccReads: Int
-  totalReads: Int
-  truncated: Int
-  unmappedReads: Int
-  updatedAt: ISO8601DateTime!
-  useTaxonWhitelist: Boolean!
-  wdlVersion: String
-}
-
-type Project {
-  backgroundFlag: Int
-  createdAt: ISO8601DateTime!
-  creator: User
-  daysToKeepSamplePrivate: Int!
-  description: String
-  id: Int!
-  maxInputFragmentsDefault: Int
-  name: String!
-  publicAccess: Int!
-  samples: [Sample!]
-  subsampleDefault: Int
-  totalSampleCount: Int!
-  updatedAt: ISO8601DateTime!
-}
-
-type SampleDetails {
-  dbSample: DbSample
-  derivedSampleOutput: DerivedSampleOutput
-  metadata: SampleMetadata
-  mngsRunInfo: MngsRunInfo
-  uploader: SampleUploader!
-  workflowRunsCountByWorkflow: String
-}
-
-type SampleList {
-  sampleIds: [Int!]
-  samples: [Sample!]!
-}
-
-type SampleMetadata {
-  collectionDate: String
-  collectionLocationV2: String
-  nucleotideType: String
-  sampleType: String
-  waterControl: String
-  metadata: [query_SampleMetadata_metadata_items]
-  additional_info: query_SampleMetadata_additional_info
-}
-
-type SampleReadsStats {
-  initialReads: Int
-  name: String
-  pipelineVersion: String
-  sampleId: ID!
-  steps: [SampleSteps!]
-  wdlVersion: String
-}
-
-type SampleReadsStatsList {
-  sampleReadsStats: [SampleReadsStats!]!
-}
-
-type SampleSteps {
-  name: String
-  readsAfter: Int
-}
-
-type SampleSummaryStats {
-  adjustedRemainingReads: Int
-  compressionRatio: Float
-  insertSizeMean: Float
-  insertSizeStandardDeviation: Float
-  lastProcessedAt: ISO8601DateTime
-  percentRemaining: Float
-  qcPercent: Float
-  readsAfterCzidDedup: Int
-  readsAfterPriceseq: Int
-  readsAfterStar: Int
-  readsAfterTrimmomatic: Int
-  unmappedReads: Int
-}
-
-type SampleUploader {
-  id: Int!
-  name: String
-}
-
-type User {
-  archetypes: String!
-  createdByUserId: BigInt!
-  email: String!
-  id: ID!
-  institution: String!
-  name: String!
-  role: Int!
-  segments: String!
-}
-
-type WorkflowRun {
-  cachedResults: String
-  createdAt: ISO8601DateTime!
-  deprecated: Boolean!
-  errorMessage: String
-  executedAt: ISO8601DateTime
-  inputsJson: String
-  rerunFrom: Int
-  s3OutputPrefix: String
-  sample: Sample
-  sampleId: Int
-  sfnExecutionArn: String
-  status: String!
-  timeToFinalized: Int
-  updatedAt: ISO8601DateTime!
-  wdlVersion: String
-  workflow: String!
 }
 
 type AmrDeprecatedResults {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -62,6 +62,7 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   Background(snapshotLinkId: String): Background @httpOperation(path: "/pub/{args.snapshotLinkId}/backgrounds.json", httpMethod: GET)
   BulkDownloadDetails(bulkDownloadId: String): BulkDownloadDetails @httpOperation(path: "/bulk_downloads/{args.bulkDownloadId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   BulkDownloadCGOverview(input: queryInput_BulkDownloadCGOverview_input_Input): ConsensusGenomeOverviewRows @httpOperation(path: "/bulk_downloads", httpMethod: POST)
+  consensusGenomes(input: queryInput_consensusGenomes_input_Input): [query_consensusGenomes_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   ConsensusGenomeWorkflowResults(workflowRunId: String): ConsensusGenomeWorkflowResults @httpOperation(path: "/workflow_runs/{args.workflowRunId}/results", httpMethod: GET)
   CoverageVizSummary(snapshotLinkId: String, sampleId: String): [query_CoverageVizSummary_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/coverage_viz_summary", httpMethod: GET)
   MetadataFields(snapshotLinkId: String, input: queryInput_MetadataFields_input_Input): [query_MetadataFields_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/metadata_fields", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
@@ -70,6 +71,8 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   Pathogens(snapshotLinkId: String, sampleId: String, workflowVersionId: String): [query_Pathogens_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   PersistedBackground(projectId: String): PersistedBackground @httpOperation(path: "/persisted_backgrounds/{args.projectId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   PipelineData(sampleId: String, workflowVersionId: String): PipelineData @httpOperation(path: "/samples/{args.sampleId}/pipeline_viz/{args.workflowVersionId}.json", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
+  samples(input: queryInput_samples_input_Input): [query_samples_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
+  sequencingReads(input: queryInput_sequencingReads_input_Input): [query_sequencingReads_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   Taxons(snapshotLinkId: String, sampleId: String, workflowVersionId: String): [query_Taxons_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   TaxonDist(backgroundId: String, taxonId: String): TaxonDist @httpOperation(path: "/backgrounds/{args.backgroundId}/show_taxon_dist.json?taxid={args.taxonId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   UserBlastAnnotations(sampleId: String, workflowVersionId: String): [query_UserBlastAnnotations_items] @httpOperation(path: "/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
@@ -2401,6 +2404,142 @@ input queryInput_BulkDownloadCGOverview_input_Input {
   authenticityToken: String!
 }
 
+type query_consensusGenomes_items {
+  producingRunId: String
+  taxon: query_consensusGenomes_items_taxon
+  referenceGenome: query_consensusGenomes_items_referenceGenome
+  metric: query_consensusGenomes_items_metric
+  sequencingRead: query_consensusGenomes_items_sequencingRead
+}
+
+type query_consensusGenomes_items_taxon {
+  name: String!
+}
+
+type query_consensusGenomes_items_referenceGenome {
+  accessionId: String
+  accessionName: String
+}
+
+type query_consensusGenomes_items_metric {
+  coverageDepth: Float
+  totalReads: Int
+  gcPercent: Float
+  refSnps: Int
+  percentIdentity: Float
+  nActg: Int
+  percentGenomeCalled: Float
+  nMissing: Int
+  nAmbiguous: Int
+  referenceGenomeLength: Float
+}
+
+type query_consensusGenomes_items_sequencingRead {
+  nucleicAcid: String!
+  protocol: String
+  medakaModel: String
+  technology: String!
+  taxon: query_consensusGenomes_items_sequencingRead_taxon
+  sample: query_consensusGenomes_items_sequencingRead_sample
+}
+
+type query_consensusGenomes_items_sequencingRead_taxon {
+  name: String!
+}
+
+type query_consensusGenomes_items_sequencingRead_sample {
+  railsSampleId: Int
+  name: String!
+  notes: String
+  collectionLocation: String!
+  sampleType: String!
+  waterControl: Boolean
+  hostOrganism: query_consensusGenomes_items_sequencingRead_sample_hostOrganism
+  collection: query_consensusGenomes_items_sequencingRead_sample_collection
+  ownerUser: query_consensusGenomes_items_sequencingRead_sample_ownerUser
+  metadatas: query_consensusGenomes_items_sequencingRead_sample_metadatas!
+}
+
+type query_consensusGenomes_items_sequencingRead_sample_hostOrganism {
+  name: String
+}
+
+type query_consensusGenomes_items_sequencingRead_sample_collection {
+  name: String
+  public: Boolean
+}
+
+type query_consensusGenomes_items_sequencingRead_sample_ownerUser {
+  name: String
+}
+
+type query_consensusGenomes_items_sequencingRead_sample_metadatas {
+  edges: [query_consensusGenomes_items_sequencingRead_sample_metadatas_edges_items]!
+}
+
+type query_consensusGenomes_items_sequencingRead_sample_metadatas_edges_items {
+  node: query_consensusGenomes_items_sequencingRead_sample_metadatas_edges_items_node!
+}
+
+type query_consensusGenomes_items_sequencingRead_sample_metadatas_edges_items_node {
+  fieldName: String!
+  value: String!
+}
+
+input queryInput_consensusGenomes_input_Input {
+  where: queryInput_consensusGenomes_input_where_Input
+  orderBy: queryInput_consensusGenomes_input_orderBy_Input
+  todoRemove: queryInput_consensusGenomes_input_todoRemove_Input
+}
+
+input queryInput_consensusGenomes_input_where_Input {
+  producingRunId: queryInput_consensusGenomes_input_where_producingRunId_Input
+}
+
+input queryInput_consensusGenomes_input_where_producingRunId_Input {
+  _in: [String]
+}
+
+input queryInput_consensusGenomes_input_orderBy_Input {
+  accession: queryInput_consensusGenomes_input_orderBy_accession_Input
+  metrics: queryInput_consensusGenomes_input_orderBy_metrics_Input
+}
+
+input queryInput_consensusGenomes_input_orderBy_accession_Input {
+  accessionId: String
+}
+
+input queryInput_consensusGenomes_input_orderBy_metrics_Input {
+  coverageDepth: String
+  totalReads: String
+  gcPercent: String
+  refSnps: String
+  percentIdentity: String
+  nActg: String
+  percentGenomeCalled: String
+  nMissing: String
+  nAmbiguous: String
+  referenceGenomeLength: String
+}
+
+input queryInput_consensusGenomes_input_todoRemove_Input {
+  domain: String
+  workflow: String
+  projectId: String
+  visibility: String
+  search: String
+  time: [String]
+  host: [Int]
+  taxaLevels: [String]
+  taxons: [Int]
+  locationV2: [String]
+  tissue: [String]
+  orderBy: String
+  orderDir: String
+  offset: Int
+  limit: Int
+}
+
 type ConsensusGenomeWorkflowResults {
   metric_consensus_genome: query_ConsensusGenomeWorkflowResults_metric_consensus_genome
   reference_genome: query_ConsensusGenomeWorkflowResults_reference_genome
@@ -2739,9 +2878,8 @@ type query_PipelineData_edges_items_files_items {
 }
 
 type query_samples_items {
-  id: String
+  id: String!
   railsSampleId: Int
-  required: JSON
 }
 
 input queryInput_samples_input_Input {
@@ -2756,7 +2894,7 @@ input queryInput_samples_input_where_Input {
   name: queryInput_samples_input_where_name_Input
   collectionLocation: queryInput_samples_input_where_collectionLocation_Input
   sampleType: queryInput_samples_input_where_sampleType_Input
-  hostTaxon: queryInput_samples_input_where_hostTaxon_Input
+  hostOrganism: queryInput_samples_input_where_hostOrganism_Input
   sequencingReads: queryInput_samples_input_where_sequencingReads_Input
 }
 
@@ -2776,16 +2914,25 @@ input queryInput_samples_input_where_sampleType_Input {
   _in: [String]
 }
 
-input queryInput_samples_input_where_hostTaxon_Input {
-  upstreamDatabaseIdentifier: queryInput_samples_input_where_hostTaxon_upstreamDatabaseIdentifier_Input
+input queryInput_samples_input_where_hostOrganism_Input {
+  name: queryInput_samples_input_where_hostOrganism_name_Input
 }
 
-input queryInput_samples_input_where_hostTaxon_upstreamDatabaseIdentifier_Input {
+input queryInput_samples_input_where_hostOrganism_name_Input {
   _in: [String]
 }
 
 input queryInput_samples_input_where_sequencingReads_Input {
+  taxon: queryInput_samples_input_where_sequencingReads_taxon_Input
   consensusGenomes: queryInput_samples_input_where_sequencingReads_consensusGenomes_Input
+}
+
+input queryInput_samples_input_where_sequencingReads_taxon_Input {
+  name: queryInput_samples_input_where_sequencingReads_taxon_name_Input
+}
+
+input queryInput_samples_input_where_sequencingReads_taxon_name_Input {
+  _in: [String]
 }
 
 input queryInput_samples_input_where_sequencingReads_consensusGenomes_Input {
@@ -2794,15 +2941,10 @@ input queryInput_samples_input_where_sequencingReads_consensusGenomes_Input {
 
 input queryInput_samples_input_where_sequencingReads_consensusGenomes_taxon_Input {
   name: queryInput_samples_input_where_sequencingReads_consensusGenomes_taxon_name_Input
-  producingRunId: queryInput_samples_input_where_sequencingReads_consensusGenomes_taxon_producingRunId_Input
 }
 
 input queryInput_samples_input_where_sequencingReads_consensusGenomes_taxon_name_Input {
   _in: [String]
-}
-
-input queryInput_samples_input_where_sequencingReads_consensusGenomes_taxon_producingRunId_Input {
-  _in: [Int]
 }
 
 input queryInput_samples_input_orderBy_Input {
@@ -2815,7 +2957,28 @@ input queryInput_samples_input_sequencingReadsInput_Input {
 }
 
 input queryInput_samples_input_sequencingReadsInput_where_Input {
-  consensusGenomes: JSON
+  taxon: queryInput_samples_input_sequencingReadsInput_where_taxon_Input
+  consensusGenomes: queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_Input
+}
+
+input queryInput_samples_input_sequencingReadsInput_where_taxon_Input {
+  name: queryInput_samples_input_sequencingReadsInput_where_taxon_name_Input
+}
+
+input queryInput_samples_input_sequencingReadsInput_where_taxon_name_Input {
+  _in: [String]
+}
+
+input queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_Input {
+  taxon: queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_taxon_Input
+}
+
+input queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_taxon_Input {
+  name: queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_taxon_name_Input
+}
+
+input queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_taxon_name_Input {
+  _in: [String]
 }
 
 input queryInput_samples_input_todoRemove_Input {
@@ -2829,6 +2992,169 @@ input queryInput_samples_input_todoRemove_Input {
   workflow: String
   projectId: String
   listAllIds: Boolean
+}
+
+type query_sequencingReads_items {
+  id: String!
+  nucleicAcid: String!
+  protocol: String
+  medakaModel: String
+  technology: String!
+  taxon: query_sequencingReads_items_taxon
+  sample: query_sequencingReads_items_sample
+  consensusGenomes: query_sequencingReads_items_consensusGenomes!
+}
+
+type query_sequencingReads_items_taxon {
+  name: String!
+}
+
+type query_sequencingReads_items_sample {
+  railsSampleId: Int
+  name: String!
+  notes: String
+  collectionLocation: String!
+  sampleType: String!
+  waterControl: Boolean
+  hostOrganism: query_sequencingReads_items_sample_hostOrganism
+  collection: query_sequencingReads_items_sample_collection
+  ownerUser: query_sequencingReads_items_sample_ownerUser
+  metadatas: query_sequencingReads_items_sample_metadatas!
+}
+
+type query_sequencingReads_items_sample_hostOrganism {
+  name: String!
+}
+
+type query_sequencingReads_items_sample_collection {
+  name: String
+  public: Boolean
+}
+
+type query_sequencingReads_items_sample_ownerUser {
+  name: String
+}
+
+type query_sequencingReads_items_sample_metadatas {
+  edges: [query_sequencingReads_items_sample_metadatas_edges_items]!
+}
+
+type query_sequencingReads_items_sample_metadatas_edges_items {
+  node: query_sequencingReads_items_sample_metadatas_edges_items_node!
+}
+
+type query_sequencingReads_items_sample_metadatas_edges_items_node {
+  fieldName: String!
+  value: String!
+}
+
+type query_sequencingReads_items_consensusGenomes {
+  edges: [query_sequencingReads_items_consensusGenomes_edges_items]!
+}
+
+type query_sequencingReads_items_consensusGenomes_edges_items {
+  node: query_sequencingReads_items_consensusGenomes_edges_items_node!
+}
+
+type query_sequencingReads_items_consensusGenomes_edges_items_node {
+  producingRunId: String
+  taxon: query_sequencingReads_items_consensusGenomes_edges_items_node_taxon
+  referenceGenome: query_sequencingReads_items_consensusGenomes_edges_items_node_referenceGenome
+  metric: query_sequencingReads_items_consensusGenomes_edges_items_node_metric
+}
+
+type query_sequencingReads_items_consensusGenomes_edges_items_node_taxon {
+  name: String!
+}
+
+type query_sequencingReads_items_consensusGenomes_edges_items_node_referenceGenome {
+  accessionId: String
+  accessionName: String
+}
+
+type query_sequencingReads_items_consensusGenomes_edges_items_node_metric {
+  coverageDepth: Float
+  totalReads: Int
+  gcPercent: Float
+  refSnps: Int
+  percentIdentity: Float
+  nActg: Int
+  percentGenomeCalled: Float
+  nMissing: Int
+  nAmbiguous: Int
+  referenceGenomeLength: Float
+}
+
+input queryInput_sequencingReads_input_Input {
+  where: queryInput_sequencingReads_input_where_Input
+  orderBy: queryInput_sequencingReads_input_orderBy_Input
+  consensusGenomesInput: queryInput_sequencingReads_input_consensusGenomesInput_Input
+  todoRemove: queryInput_sequencingReads_input_todoRemove_Input
+}
+
+input queryInput_sequencingReads_input_where_Input {
+  id: queryInput_sequencingReads_input_where_id_Input
+}
+
+input queryInput_sequencingReads_input_where_id_Input {
+  _in: [String]
+}
+
+input queryInput_sequencingReads_input_orderBy_Input {
+  protocol: String
+  technology: String
+  medakaModel: String
+  nucleicAcid: String
+  sample: queryInput_sequencingReads_input_orderBy_sample_Input
+}
+
+input queryInput_sequencingReads_input_orderBy_sample_Input {
+  name: String
+  notes: String
+  sampleType: String
+  waterControl: String
+  collectionLocation: String
+  hostOrganism: queryInput_sequencingReads_input_orderBy_sample_hostOrganism_Input
+  metadata: queryInput_sequencingReads_input_orderBy_sample_metadata_Input
+}
+
+input queryInput_sequencingReads_input_orderBy_sample_hostOrganism_Input {
+  name: String
+}
+
+input queryInput_sequencingReads_input_orderBy_sample_metadata_Input {
+  fieldName: String
+  dir: String
+}
+
+input queryInput_sequencingReads_input_consensusGenomesInput_Input {
+  where: queryInput_sequencingReads_input_consensusGenomesInput_where_Input
+}
+
+input queryInput_sequencingReads_input_consensusGenomesInput_where_Input {
+  producingRunId: queryInput_sequencingReads_input_consensusGenomesInput_where_producingRunId_Input
+}
+
+input queryInput_sequencingReads_input_consensusGenomesInput_where_producingRunId_Input {
+  _in: [String]
+}
+
+input queryInput_sequencingReads_input_todoRemove_Input {
+  domain: String
+  workflow: String
+  projectId: String
+  visibility: String
+  search: String
+  time: [String]
+  host: [Int]
+  taxaLevels: [String]
+  taxons: [Int]
+  locationV2: [String]
+  tissue: [String]
+  orderBy: String
+  orderDir: String
+  offset: Int
+  limit: Int
 }
 
 type query_Taxons_items {
@@ -2944,6 +3270,16 @@ input queryInput_workflowRuns_input_todoRemove_Input {
 
 input queryInput_workflowRuns_input_orderBy_Input {
   startedAt: String
+  workflowVersion: queryInput_workflowRuns_input_orderBy_workflowVersion_Input
+}
+
+input queryInput_workflowRuns_input_orderBy_workflowVersion_Input {
+  version: String
+  workflow: queryInput_workflowRuns_input_orderBy_workflowVersion_workflow_Input
+}
+
+input queryInput_workflowRuns_input_orderBy_workflowVersion_workflow_Input {
+  name: String
 }
 
 input queryInput_workflowRuns_input_where_Input {

--- a/tests/utils/ExampleQueryFiles.ts
+++ b/tests/utils/ExampleQueryFiles.ts
@@ -1,45 +1,22 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from "fs";
 import { join } from "path";
 
-const exampleQueriesDir = "../../example-queries";
-
-const getZipLinkExampleQueryPath = () : string => {
-  return join(__dirname, `${exampleQueriesDir}/zip-link-query.graphql`);
-};
-
-export const getZipLinkExampleQuery = () : string => {
-  return readFileSync(getZipLinkExampleQueryPath(), { encoding: "utf8" });
+export function getExampleQuery(graphqlFile: string): string {
+  return readFileSync(
+    join(__dirname, `../../example-queries/${graphqlFile}.graphql`),
+    {
+      encoding: "utf8",
+    }
+  );
 }
 
-
-const getBulkDownloadCGOverviewExampleQueryPath = () : string => {
-  return join(__dirname, `${exampleQueriesDir}/bulk-download-cg-overview-query.graphql`);
-};
-
-export const getBulkDownloadCGOverviewExampleQuery = () : string => {
-  return readFileSync(getBulkDownloadCGOverviewExampleQueryPath(), { encoding: "utf8" });
+export function getSampleResponse(responseFile: string): any {
+  return JSON.parse(
+    readFileSync(
+      join(__dirname, `../../sample-responses/${responseFile}.json`),
+      {
+        encoding: "utf8",
+      }
+    )
+  );
 }
-
-const getBulkDownloadCGOverviewResponsePath = () : string => {
-  return join(__dirname, "../../sample-responses/cgOverview.json");
-}
-
-export const getBulkDownloadCGOverviewResponse = () : string => {
-  return readFileSync(getBulkDownloadCGOverviewResponsePath(), { encoding: "utf8" });
-} 
-
-const getCreateBulkDownloadExampleMutationPath = () : string => {
-  return join(__dirname, `${exampleQueriesDir}/create-bulk-download-query.graphql`);
-}
-
-export const getCreateBulkDownloadExampleMutation = () : string => {
-  return readFileSync(getCreateBulkDownloadExampleMutationPath(), { encoding: "utf8" });
-}
-
-const getCreateBulkDownloadResponsePath = () : string => {
-  return join(__dirname, "../../sample-responses/bulkDownload.json");
-}
-
-export const getCreateBulkDownloadResponse = () : string => {
-  return readFileSync(getCreateBulkDownloadResponsePath(), { encoding: "utf8" });
-} 

--- a/tests/utils/ExampleQueryFiles.ts
+++ b/tests/utils/ExampleQueryFiles.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 
+/**
+ * @param graphqlFile file name (excludes .graphql file extension)
+ * @returns example query as a string
+ */
 export function getExampleQuery(graphqlFile: string): string {
   return readFileSync(
     join(__dirname, `../../example-queries/${graphqlFile}.graphql`),
@@ -10,6 +14,10 @@ export function getExampleQuery(graphqlFile: string): string {
   );
 }
 
+/**
+ * @param responseFile file name (excludes .json file extension)
+ * @returns JSON.parse()d value from the response file
+ */
 export function getSampleResponse(responseFile: string): any {
   return JSON.parse(
     readFileSync(


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9351]
[CZID-9353]

## Description

These 2 endpoints will be used for retrieving the actual (paginated) sample rows. The will used the list of perfectly filtered IDs as input in NextGen.

`sequencingReads` can fully substitute for querying `samples` since it's a 1:1 relationship (can handle sorting on nested `Sample`s). It will also be the query that handles sorting by metadata fields, which (while Rails contains all metadata) will require the Federation layer to query a different Rails endpoint for the `Sample`s sorted by metadata.

`consensusGenomes` is necessary for sorting on `ConsensusGenome` fields. The query itself is not sufficient due to `Sample`s that don't have `ConsensusGenome`s, so the FE will have to stitch the result together with those `Sample`s.

Also updated the `samples` endpoint:

- Added inputs for the 2 separate queries we'll have to "`OUTER JOIN`" to filter by taxon.
- Fixed some of the `id` logic.

Separates out the test queries into their own files so that Omar can use them for his API diff testing. Also cleans up the example files util (we don't need a new function every test).

## Tests

Unused endpoints.


[CZID-9351]: https://czi-tech.atlassian.net/browse/CZID-9351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CZID-9353]: https://czi-tech.atlassian.net/browse/CZID-9353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ