### PR TITLE
feat: Update paginated endpoints with limit/offset

### DIFF
--- a/example-queries/consensus-genomes-query.graphql
+++ b/example-queries/consensus-genomes-query.graphql
@@ -1,6 +1,5 @@
 query TestQuery {
     consensusGenomes(input: {
-        after: "{\"limit\":50,\"offset\":100}"
         where: {
             producingRunId: {
                 _in: ["abc", "def"]
@@ -10,10 +9,6 @@ query TestQuery {
             search: "abc"
         }
     }) {
-        pageInfo {
-            hasNextPage
-            endCursor
-        }
         producingRunId
         taxon {
             name

--- a/example-queries/consensus-genomes-query.graphql
+++ b/example-queries/consensus-genomes-query.graphql
@@ -1,14 +1,19 @@
 query TestQuery {
     consensusGenomes(input: {
+        after: "{\"limit\":50,\"offset\":100}"
         where: {
             producingRunId: {
-            _in: ["abc", "def"]
+                _in: ["abc", "def"]
             }
         }
         todoRemove: {
             search: "abc"
         }
     }) {
+        pageInfo {
+            hasNextPage
+            endCursor
+        }
         producingRunId
         taxon {
             name

--- a/example-queries/sequencing-reads-query.graphql
+++ b/example-queries/sequencing-reads-query.graphql
@@ -1,33 +1,38 @@
 query TestQuery {
     sequencingReads(input: {
+        after: "{\"limit\":50,\"offset\":100}"
         where: {
             id: {
-            _in: ["abc", "def"]
+                _in: ["abc", "def"]
             }
         }
         todoRemove: {
             search: "abc"
         }
     }) {
-    id
-    sample {
-        metadatas {
-        edges {
-            node {
-            fieldName
-            value
+        pageInfo {
+            hasNextPage
+            endCursor
+        }
+        id
+        sample {
+            metadatas {
+                edges {
+                    node {
+                    fieldName
+                    value
+                    }
+                }
             }
         }
-        }
-    }
-    consensusGenomes {
-        edges {
-        node {
-            taxon {
-            name
+        consensusGenomes {
+            edges {
+                node {
+                    taxon {
+                        name
+                    }
+                }
             }
         }
-        }
-    }
     }
 }

--- a/example-queries/sequencing-reads-query.graphql
+++ b/example-queries/sequencing-reads-query.graphql
@@ -12,7 +12,12 @@ query TestQuery {
         }
     }) {
         id
+        taxon {
+            name
+        }
         sample {
+            collectionLocation
+            waterControl
             metadatas {
                 edges {
                     node {

--- a/example-queries/sequencing-reads-query.graphql
+++ b/example-queries/sequencing-reads-query.graphql
@@ -1,6 +1,7 @@
 query TestQuery {
     sequencingReads(input: {
-        after: "{\"limit\":50,\"offset\":100}"
+        limit: 50
+        offset: 100
         where: {
             id: {
                 _in: ["abc", "def"]
@@ -10,10 +11,6 @@ query TestQuery {
             search: "abc"
         }
     }) {
-        pageInfo {
-            hasNextPage
-            endCursor
-        }
         id
         sample {
             metadatas {

--- a/example-queries/sequencing-reads-query.graphql
+++ b/example-queries/sequencing-reads-query.graphql
@@ -30,6 +30,7 @@ query TestQuery {
         consensusGenomes {
             edges {
                 node {
+                    producingRunId
                     taxon {
                         name
                     }

--- a/json-schemas/consensusGenomesRequest.json
+++ b/json-schemas/consensusGenomesRequest.json
@@ -1,6 +1,12 @@
 {
     "type": "object",
     "properties": {
+        "after": {
+            "type": "string"
+        },
+        "first": {
+            "type": "integer"
+        },
         "where": {
             "type": "object",
             "properties": {
@@ -124,12 +130,6 @@
                 },
                 "orderDir": {
                     "type": "string"
-                },
-                "offset": {
-                    "type": "integer"
-                },
-                "limit": {
-                    "type": "integer"
                 }
             }
         }

--- a/json-schemas/consensusGenomesRequest.json
+++ b/json-schemas/consensusGenomesRequest.json
@@ -1,10 +1,10 @@
 {
     "type": "object",
     "properties": {
-        "after": {
-            "type": "string"
+        "limit": {
+            "type": "integer"
         },
-        "first": {
+        "offset": {
             "type": "integer"
         },
         "where": {

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -118,6 +118,9 @@
                             "waterControl": {
                                 "type": "boolean"
                             },
+                            "uploadError": {
+                                "type": "string"
+                            },
                             "hostOrganism": {
                                 "type": "object",
                                 "properties": {

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -3,18 +3,6 @@
     "items": {
         "type": "object",
         "properties": {
-            "pageInfo": {
-                "type": "object",
-                "properties": {
-                    "hasNextPage": {
-                        "type": "boolean"
-                    },
-                    "endCursor": {
-                        "type": "string"
-                    }
-                },
-                "required": ["hasNextPage"]
-            },
             "producingRunId": {
                 "type": "string"
             },
@@ -181,7 +169,6 @@
                 },
                 "required": ["nucleicAcid", "technology"]
             }
-        },
-        "required": ["pageInfo"]
+        }
     }
 }

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -128,16 +128,11 @@
                                     }
                                 }
                             },
-                            "ownerUser": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "number"
-                                    },
-                                    "name": {
-                                        "type": "string"
-                                    }
-                                }
+                            "ownerUserId": {
+                                "type": "number"
+                            },
+                            "ownerUserName": {
+                                "type": "string"
                             },
                             "metadatas": {
                                 "type": "object",

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -131,6 +131,9 @@
                             "ownerUser": {
                                 "type": "object",
                                 "properties": {
+                                    "id": {
+                                        "type": "number"
+                                    },
                                     "name": {
                                         "type": "string"
                                     }

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -3,6 +3,18 @@
     "items": {
         "type": "object",
         "properties": {
+            "pageInfo": {
+                "type": "object",
+                "properties": {
+                    "hasNextPage": {
+                        "type": "boolean"
+                    },
+                    "endCursor": {
+                        "type": "string"
+                    }
+                },
+                "required": ["hasNextPage"]
+            },
             "producingRunId": {
                 "type": "string"
             },
@@ -166,6 +178,7 @@
                 },
                 "required": ["nucleicAcid", "technology"]
             }
-        }
+        },
+        "required": ["pageInfo"]
     }
 }

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -26,7 +26,7 @@
                     }
                 }
             },
-            "metric": {
+            "metrics": {
                 "type": "object",
                 "properties": {
                     "coverageDepth": {

--- a/json-schemas/sequencingReadsRequest.json
+++ b/json-schemas/sequencingReadsRequest.json
@@ -1,10 +1,10 @@
 {
     "type": "object",
     "properties": {
-        "after": {
-            "type": "string"
+        "limit": {
+            "type": "integer"
         },
-        "first": {
+        "offset": {
             "type": "integer"
         },
         "where": {

--- a/json-schemas/sequencingReadsRequest.json
+++ b/json-schemas/sequencingReadsRequest.json
@@ -1,6 +1,12 @@
 {
     "type": "object",
     "properties": {
+        "after": {
+            "type": "string"
+        },
+        "first": {
+            "type": "integer"
+        },
         "where": {
             "type": "object",
             "properties": {
@@ -153,12 +159,6 @@
                 },
                 "orderDir": {
                     "type": "string"
-                },
-                "offset": {
-                    "type": "integer"
-                },
-                "limit": {
-                    "type": "integer"
                 }
             }
         }

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -71,16 +71,11 @@
                             }
                         }
                     },
-                    "ownerUser": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "number"
-                            },
-                            "name": {
-                                "type": "string"
-                            }
-                        }
+                    "ownerUserId": {
+                        "type": "number"
+                    },
+                    "ownerUserName": {
+                        "type": "string"
                     },
                     "metadatas": {
                         "type": "object",

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -3,18 +3,6 @@
     "items": {
         "type": "object",
         "properties": {
-            "pageInfo": {
-                "type": "object",
-                "properties": {
-                    "hasNextPage": {
-                        "type": "boolean"
-                    },
-                    "endCursor": {
-                        "type": "string"
-                    }
-                },
-                "required": ["hasNextPage"]
-            },
             "id": {
                 "type": "string"
             },
@@ -200,6 +188,6 @@
                 "required": ["edges"]
             }
         },
-        "required": ["pageInfo", "id", "nucleicAcid", "technology", "consensusGenomes"]
+        "required": ["id", "nucleicAcid", "technology", "consensusGenomes"]
     }
 }

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -60,6 +60,9 @@
                     "waterControl": {
                         "type": "boolean"
                     },
+                    "uploadError": {
+                        "type": "string"
+                    },
                     "hostOrganism": {
                         "type": "object",
                         "properties": {
@@ -152,7 +155,7 @@
                                                 }
                                             }
                                         },
-                                        "metric": {
+                                        "metrics": {
                                             "type": "object",
                                             "properties": {
                                                 "coverageDepth": {

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -3,6 +3,18 @@
     "items": {
         "type": "object",
         "properties": {
+            "pageInfo": {
+                "type": "object",
+                "properties": {
+                    "hasNextPage": {
+                        "type": "boolean"
+                    },
+                    "endCursor": {
+                        "type": "string"
+                    }
+                },
+                "required": ["hasNextPage"]
+            },
             "id": {
                 "type": "string"
             },
@@ -185,6 +197,6 @@
                 "required": ["edges"]
             }
         },
-        "required": ["id", "nucleicAcid", "technology", "consensusGenomes"]
+        "required": ["pageInfo", "id", "nucleicAcid", "technology", "consensusGenomes"]
     }
 }

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -74,6 +74,9 @@
                     "ownerUser": {
                         "type": "object",
                         "properties": {
+                            "id": {
+                                "type": "number"
+                            },
                             "name": {
                                 "type": "string"
                             }

--- a/json-schemas/workflowRunsRequest.json
+++ b/json-schemas/workflowRunsRequest.json
@@ -55,6 +55,12 @@
                 "workflow": {
                     "type": "string"
                 },
+                "orderBy": {
+                    "type": "string"
+                },
+                "orderDir": {
+                    "type": "string"
+                },
                 "authenticityToken": {
                     "type": "string"
                 }

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -283,6 +283,7 @@ export const resolvers: Resolvers = {
                 public: Boolean(sampleInfo?.public),
               },
               ownerUser: {
+                id: sample?.uploader?.id,
                 // TODO: Make runner come from Workflows stitched with the user service when NextGen
                 // ready.
                 name: run.runner?.name ?? sample?.uploader?.name,
@@ -635,6 +636,7 @@ export const resolvers: Resolvers = {
                 public: Boolean(sampleInfo?.public),
               },
               ownerUser: {
+                id: sample?.uploader?.id,
                 // TODO: Make runner come from Workflows stitched with the user service when NextGen
                 // ready.
                 name: run.runner?.name ?? sample?.uploader?.name,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -230,10 +230,6 @@ export const resolvers: Resolvers = {
         const sampleInfo = sample?.info;
         const sampleMetadata = sample?.metadata;
         return {
-          pageInfo: {
-            hasNextPage: workflow_runs.length === 50,
-            endCursor: String(offset + 50),
-          },
           producingRunId: run.id?.toString(),
           taxon: {
             name: inputs?.taxon_name,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -738,7 +738,6 @@ export const resolvers: Resolvers = {
           authenticity_token: input?.todoRemove?.authenticityToken,
           workflowRunIds: input.where.id._in.map((id) => id && parseInt(id)),
         };
-
         const { workflowRuns } = await postWithCSRF(
           `/workflow_runs/valid_consensus_genome_workflow_runs`,
           body,
@@ -761,10 +760,10 @@ export const resolvers: Resolvers = {
             domain: input?.todoRemove?.domain,
             projectId: input?.todoRemove?.projectId,
             search: input?.todoRemove?.search,
-            // Workflows Service will cover sorting by time, version, or creation source, but
-            // Rails doesn't support the latter 2!
-            orderBy: input?.todoRemove.orderBy,
-            orderDir: input?.todoRemove.orderDir,
+            // TODO: Cover sorting by time, version, or creation source (though Rails doesn't
+            // actually support the latter 2).
+            orderBy: input?.todoRemove?.orderBy,
+            orderDir: input?.todoRemove?.orderDir,
             host: input?.todoRemove?.host,
             locationV2: input?.todoRemove?.locationV2,
             taxon: input?.todoRemove?.taxon,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -181,7 +181,6 @@ export const resolvers: Resolvers = {
     },
     consensusGenomes: async (root, args, context) => {
       const input = args.input;
-      const offset = parseInt(input?.after ?? "0");
 
       // The comments in the formatUrlParams() call correspond to the line in the current
       // codebase's callstack where the params are set, so help ensure we're not missing anything.
@@ -212,8 +211,8 @@ export const resolvers: Resolvers = {
             workflow: input?.todoRemove?.workflow,
             //  - DiscoveryDataLayer.ts
             //    await this._collection.fetchDataCallback({
-            limit: 50,
-            offset,
+            limit: input?.limit,
+            offset: input?.offset,
             listAllIds: false,
           }),
         args,
@@ -238,7 +237,7 @@ export const resolvers: Resolvers = {
             accessionId: inputs?.accession_id,
             accessionName: inputs?.accession_name,
           },
-          metric: {
+          metrics: {
             coverageDepth: run.cached_results?.coverage_viz?.coverage_depth,
             totalReads: qualityMetrics?.total_reads,
             gcPercent: qualityMetrics?.gc_percent,
@@ -509,7 +508,6 @@ export const resolvers: Resolvers = {
     },
     sequencingReads: async (root, args, context) => {
       const input = args.input;
-      const offset = parseInt(input?.after ?? "0");
 
       // The comments in the formatUrlParams() call correspond to the line in the current
       // codebase's callstack where the params are set, so help ensure we're not missing anything.
@@ -540,8 +538,8 @@ export const resolvers: Resolvers = {
             workflow: input?.todoRemove?.workflow,
             //  - DiscoveryDataLayer.ts
             //    await this._collection.fetchDataCallback({
-            limit: 50,
-            offset,
+            limit: input?.limit,
+            offset: input?.offset,
             listAllIds: false,
           }),
         args,
@@ -558,10 +556,6 @@ export const resolvers: Resolvers = {
         const sampleInfo = sample?.info;
         const sampleMetadata = sample?.metadata;
         return {
-          pageInfo: {
-            hasNextPage: workflow_runs.length === 50,
-            endCursor: String(offset + 50),
-          },
           id: sampleInfo?.id?.toString(),
           nucleicAcid: sampleMetadata?.nucleotide_type,
           protocol: inputs?.wetlab_protocol,
@@ -603,7 +597,7 @@ export const resolvers: Resolvers = {
                     accessionId: inputs?.accession_id,
                     accessionName: inputs?.accession_name,
                   },
-                  metric: {
+                  metrics: {
                     coverageDepth:
                       run.cached_results?.coverage_viz?.coverage_depth,
                     totalReads: qualityMetrics?.total_reads,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -261,6 +261,7 @@ export const resolvers: Resolvers = {
               railsSampleId: sample?.id,
               name: sampleInfo?.name,
               notes: sampleInfo?.sample_notes,
+              uploadError: sampleInfo?.result_status_description,
               collectionLocation: sampleMetadata?.collection_location_v2,
               sampleType: sampleMetadata?.sample_type,
               waterControl: sampleMetadata?.water_control,
@@ -272,7 +273,9 @@ export const resolvers: Resolvers = {
                 public: Boolean(sampleInfo?.public),
               },
               ownerUser: {
-                name: sample?.uploader?.name,
+                // TODO: Make runner come from Workflows stitched with the user service when NextGen
+                // ready.
+                name: run.runner?.name ?? sample?.uploader?.name,
               },
               metadatas: {
                 edges: getMetadataEdges(sampleMetadata),
@@ -568,6 +571,7 @@ export const resolvers: Resolvers = {
             railsSampleId: sampleInfo?.id?.toString(),
             name: sampleInfo?.name,
             notes: sampleInfo?.sample_notes,
+            uploadError: sampleInfo?.result_status_description,
             collectionLocation: sampleMetadata?.collection_location_v2,
             sampleType: sampleMetadata?.sample_type,
             waterControl: sampleMetadata?.water_control,
@@ -579,7 +583,9 @@ export const resolvers: Resolvers = {
               public: Boolean(sampleInfo?.public),
             },
             ownerUser: {
-              name: sample?.uploader?.name,
+              // TODO: Make runner come from Workflows stitched with the user service when NextGen
+              // ready.
+              name: run.runner?.name ?? sample?.uploader?.name,
             },
             metadatas: {
               edges: getMetadataEdges(sampleMetadata),

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -181,6 +181,7 @@ export const resolvers: Resolvers = {
     },
     consensusGenomes: async (root, args, context) => {
       const input = args.input;
+      const offset = parseInt(input?.after ?? "0");
 
       // The comments in the formatUrlParams() call correspond to the line in the current
       // codebase's callstack where the params are set, so help ensure we're not missing anything.
@@ -211,8 +212,8 @@ export const resolvers: Resolvers = {
             workflow: input?.todoRemove?.workflow,
             //  - DiscoveryDataLayer.ts
             //    await this._collection.fetchDataCallback({
-            limit: input?.todoRemove?.limit,
-            offset: input?.todoRemove?.offset,
+            limit: 50,
+            offset,
             listAllIds: false,
           }),
         args,
@@ -229,6 +230,10 @@ export const resolvers: Resolvers = {
         const sampleInfo = sample?.info;
         const sampleMetadata = sample?.metadata;
         return {
+          pageInfo: {
+            hasNextPage: workflow_runs.length === 50,
+            endCursor: String(offset + 50),
+          },
           producingRunId: run.id?.toString(),
           taxon: {
             name: inputs?.taxon_name,
@@ -508,6 +513,7 @@ export const resolvers: Resolvers = {
     },
     sequencingReads: async (root, args, context) => {
       const input = args.input;
+      const offset = parseInt(input?.after ?? "0");
 
       // The comments in the formatUrlParams() call correspond to the line in the current
       // codebase's callstack where the params are set, so help ensure we're not missing anything.
@@ -538,8 +544,8 @@ export const resolvers: Resolvers = {
             workflow: input?.todoRemove?.workflow,
             //  - DiscoveryDataLayer.ts
             //    await this._collection.fetchDataCallback({
-            limit: input?.todoRemove?.limit,
-            offset: input?.todoRemove?.offset,
+            limit: 50,
+            offset,
             listAllIds: false,
           }),
         args,
@@ -556,6 +562,10 @@ export const resolvers: Resolvers = {
         const sampleInfo = sample?.info;
         const sampleMetadata = sample?.metadata;
         return {
+          pageInfo: {
+            hasNextPage: workflow_runs.length === 50,
+            endCursor: String(offset + 50),
+          },
           id: sampleInfo?.id?.toString(),
           nucleicAcid: sampleMetadata?.nucleotide_type,
           protocol: inputs?.wetlab_protocol,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -282,12 +282,10 @@ export const resolvers: Resolvers = {
                 name: sample?.project_name,
                 public: Boolean(sampleInfo?.public),
               },
-              ownerUser: {
-                id: sample?.uploader?.id,
-                // TODO: Make runner come from Workflows stitched with the user service when NextGen
-                // ready.
-                name: run.runner?.name ?? sample?.uploader?.name,
-              },
+              ownerUserId: sample?.uploader?.id,
+              // TODO: Make runner come from Workflows stitched with the user service when NextGen
+              // ready.
+              ownerUserName: run.runner?.name ?? sample?.uploader?.name,
               metadatas: {
                 edges: getMetadataEdges(sampleMetadata),
               },
@@ -635,12 +633,10 @@ export const resolvers: Resolvers = {
                 name: sample?.project_name,
                 public: Boolean(sampleInfo?.public),
               },
-              ownerUser: {
-                id: sample?.uploader?.id,
-                // TODO: Make runner come from Workflows stitched with the user service when NextGen
-                // ready.
-                name: run.runner?.name ?? sample?.uploader?.name,
-              },
+              ownerUserId: sample?.uploader?.id,
+              // TODO: Make runner come from Workflows stitched with the user service when NextGen
+              // ready.
+              ownerUserName: run.runner?.name ?? sample?.uploader?.name,
               metadatas: {
                 edges: getMetadataEdges(sampleMetadata),
               },

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -763,9 +763,8 @@ export const resolvers: Resolvers = {
             search: input?.todoRemove?.search,
             // Workflows Service will cover sorting by time, version, or creation source, but
             // Rails doesn't support the latter 2!
-            orderBy:
-              input?.orderBy?.startedAt != null ? "createdAt" : undefined,
-            orderDir: input?.orderBy?.startedAt,
+            orderBy: input?.todoRemove.orderBy,
+            orderDir: input?.todoRemove.orderDir,
             host: input?.todoRemove?.host,
             locationV2: input?.todoRemove?.locationV2,
             taxon: input?.todoRemove?.taxon,

--- a/sources/entities-schema.graphql
+++ b/sources/entities-schema.graphql
@@ -947,12 +947,10 @@ type Query {
   ): [Node!]!
   files(where: FileWhereClause = null): [File!]!
   samples(where: SampleWhereClause = null): [Sample!]!
-  sequencingReads(where: SequencingReadWhereClause = null): [SequencingRead!]!
   genomicRanges(where: GenomicRangeWhereClause = null): [GenomicRange!]!
   referenceGenomes(where: ReferenceGenomeWhereClause = null): [ReferenceGenome!]!
   sequenceAlignmentIndices(where: SequenceAlignmentIndexWhereClause = null): [SequenceAlignmentIndex!]!
   metadatas(where: MetadatumWhereClause = null): [Metadatum!]!
-  consensusGenomes(where: ConsensusGenomeWhereClause = null): [ConsensusGenome!]!
   metricsConsensusGenomes(where: MetricConsensusGenomeWhereClause = null): [MetricConsensusGenome!]!
   taxa(where: TaxonWhereClause = null): [Taxon!]!
   upstreamDatabases(where: UpstreamDatabaseWhereClause = null): [UpstreamDatabase!]!

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -26,7 +26,7 @@ describe("sequencingReads query:", () => {
     const response = await execute(query, {});
 
     expect(httpUtils.get).toHaveBeenCalledWith(
-      "/workflow_runs.json?&mode=with_sample_info&search=abc&listAllIds=false",
+      "/workflow_runs.json?&mode=with_sample_info&search=abc&limit=50&offset=100&listAllIds=false",
       expect.anything(),
       expect.anything()
     );

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -61,8 +61,6 @@ describe("sequencingReads query:", () => {
 
     const result = await execute(query, {});
 
-    console.log(JSON.stringify(result));
-
     expect(result.data.sequencingReads).toHaveLength(2);
     expect(result.data.sequencingReads[0]).toEqual(
       expect.objectContaining({

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -149,4 +149,46 @@ describe("sequencingReads query:", () => {
       0
     );
   });
+
+  it("Only returns taxon object if name exists", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [{}],
+    }));
+
+    const result = await execute(query, {});
+
+    expect(result.data.sequencingReads[0].taxon).toBeNull();
+  });
+
+  it("Does not return null for required location field", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {},
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    expect(result.data.sequencingReads[0].sample.collectionLocation).toBe("");
+  });
+
+  it("Converts water control to boolean", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {
+            metadata: {
+              water_control: "Yes",
+            },
+          },
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    expect(result.data.sequencingReads[0].sample.waterControl).toBe(true);
+  });
 });

--- a/tests/WorkflowRunsQuery.test.ts
+++ b/tests/WorkflowRunsQuery.test.ts
@@ -94,8 +94,9 @@ describe("workflowRuns query:", () => {
       {}
     );
 
+    // TODO: Add support for NextGen orderBy field.
     expect(httpUtils.get).toHaveBeenCalledWith(
-      "/workflow_runs.json?&mode=basic&orderBy=createdAt&orderDir=ASC&limit=10000000&offset=0&listAllIds=false",
+      "/workflow_runs.json?&mode=basic&limit=10000000&offset=0&listAllIds=false",
       expect.anything(),
       expect.anything()
     );

--- a/tests/WorkflowRunsQuery.test.ts
+++ b/tests/WorkflowRunsQuery.test.ts
@@ -19,7 +19,7 @@ describe("workflowRuns query:", () => {
     ({ execute } = mesh$);
   });
 
-  it("Returns input sample", async () => {
+  it("Returns input sequencing read", async () => {
     (httpUtils.get as jest.Mock).mockImplementation(() => ({
       workflow_runs: [
         {
@@ -59,7 +59,7 @@ describe("workflowRuns query:", () => {
           edges: [
             {
               node: {
-                entityType: "Sample",
+                entityType: "SequencingRead",
                 inputEntityId: "2",
               },
             },
@@ -74,7 +74,7 @@ describe("workflowRuns query:", () => {
           edges: [
             {
               node: {
-                entityType: "Sample",
+                entityType: "SequencingRead",
                 inputEntityId: "4",
               },
             },

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -3254,6 +3254,8 @@ input queryInput_workflowRuns_input_todoRemove_Input {
   tissue: [String]
   visibility: String
   workflow: String
+  orderBy: String
+  orderDir: String
   authenticityToken: String
 }
 

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -17,6 +17,13 @@ directive @globalOptions(sourceName: String, endpoint: String, operationHeaders:
 directive @httpOperation(path: String, operationSpecificHeaders: ObjMap, httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap) on FIELD_DEFINITION
 
 type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") {
+  appConfig(id: ID!): AppConfig
+  pathogenList(version: String): PathogenList!
+  project(id: Int!): Project!
+  sample(sampleId: Int!): Sample!
+  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
+  samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
+  user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
   node(
     """The ID of the object."""
     id: GlobalID!
@@ -27,12 +34,10 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   ): [Node!]!
   files(where: FileWhereClause = null): [File!]!
   samples(input: queryInput_samples_input_Input): [query_samples_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
-  sequencingReads(input: queryInput_sequencingReads_input_Input): [query_sequencingReads_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   genomicRanges(where: GenomicRangeWhereClause = null): [GenomicRange!]!
   referenceGenomes(where: ReferenceGenomeWhereClause = null): [ReferenceGenome!]!
   sequenceAlignmentIndices(where: SequenceAlignmentIndexWhereClause = null): [SequenceAlignmentIndex!]!
   metadatas(where: MetadatumWhereClause = null): [Metadatum!]!
-  consensusGenomes(input: queryInput_consensusGenomes_input_Input): [query_consensusGenomes_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   metricsConsensusGenomes(where: MetricConsensusGenomeWhereClause = null): [MetricConsensusGenome!]!
   taxa(where: TaxonWhereClause = null): [Taxon!]!
   upstreamDatabases(where: UpstreamDatabaseWhereClause = null): [UpstreamDatabase!]!
@@ -50,18 +55,12 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   upstreamDatabasesAggregate(where: UpstreamDatabaseWhereClause = null): UpstreamDatabaseAggregate!
   contigsAggregate(where: ContigWhereClause = null): ContigAggregate!
   phylogeneticTreesAggregate(where: PhylogeneticTreeWhereClause = null): PhylogeneticTreeAggregate!
-  appConfig(id: ID!): AppConfig
-  pathogenList(version: String): PathogenList!
-  project(id: Int!): Project!
-  sample(sampleId: Int!): Sample!
-  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
-  samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
-  user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
   AmrDeprecatedResults(sampleId: String): AmrDeprecatedResults @httpOperation(path: "/samples/{args.sampleId}/amr.json", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   AmrWorkflowResults(workflowRunId: String): AmrWorkflowResults @httpOperation(path: "/workflow_runs/{args.workflowRunId}/results", httpMethod: GET)
   Background(snapshotLinkId: String): Background @httpOperation(path: "/pub/{args.snapshotLinkId}/backgrounds.json", httpMethod: GET)
   bulkDownloads(input: queryInput_bulkDownloads_input_Input): [query_bulkDownloads_items] @httpOperation(path: "/bulk_downloads?searchBy=&n=", httpMethod: GET)
   BulkDownloadCGOverview(input: queryInput_BulkDownloadCGOverview_input_Input): ConsensusGenomeOverviewRows @httpOperation(path: "/bulk_downloads", httpMethod: POST)
+  consensusGenomes(input: queryInput_consensusGenomes_input_Input): [query_consensusGenomes_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   ConsensusGenomeWorkflowResults(workflowRunId: String): ConsensusGenomeWorkflowResults @httpOperation(path: "/workflow_runs/{args.workflowRunId}/results", httpMethod: GET)
   CoverageVizSummary(snapshotLinkId: String, sampleId: String): [query_CoverageVizSummary_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/coverage_viz_summary", httpMethod: GET)
   MetadataFields(snapshotLinkId: String, input: queryInput_MetadataFields_input_Input): [query_MetadataFields_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/metadata_fields", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
@@ -70,6 +69,7 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   Pathogens(snapshotLinkId: String, sampleId: String, workflowVersionId: String): [query_Pathogens_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   PersistedBackground(projectId: String): PersistedBackground @httpOperation(path: "/persisted_backgrounds/{args.projectId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   PipelineData(sampleId: String, workflowVersionId: String): PipelineData @httpOperation(path: "/samples/{args.sampleId}/pipeline_viz/{args.workflowVersionId}.json", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
+  sequencingReads(input: queryInput_sequencingReads_input_Input): [query_sequencingReads_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   Taxons(snapshotLinkId: String, sampleId: String, workflowVersionId: String): [query_Taxons_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   TaxonDist(backgroundId: String, taxonId: String): TaxonDist @httpOperation(path: "/backgrounds/{args.backgroundId}/show_taxon_dist.json?taxid={args.taxonId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   UserBlastAnnotations(sampleId: String, workflowVersionId: String): [query_UserBlastAnnotations_items] @httpOperation(path: "/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
@@ -81,6 +81,7 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
 }
 
 type Mutation {
+  createUser(archetypes: String, email: String!, institution: String, name: String, role: Int, segments: String, sendActivation: Boolean): CreateUserPayload!
   createFile(entityId: ID!, entityFieldName: String!, file: FileCreate!): File!
   uploadFile(entityId: ID!, entityFieldName: String!, file: FileUpload!, expiration: Int! = 3600): MultipartUploadResponse!
   markUploadComplete(fileId: ID!): File!
@@ -121,7 +122,6 @@ type Mutation {
   createPhylogeneticTree(input: PhylogeneticTreeCreateInput!): PhylogeneticTree!
   updatePhylogeneticTree(input: PhylogeneticTreeUpdateInput!, where: PhylogeneticTreeWhereClauseMutations!): [PhylogeneticTree!]!
   deletePhylogeneticTree(where: PhylogeneticTreeWhereClauseMutations!): [PhylogeneticTree!]!
-  createUser(archetypes: String, email: String!, institution: String, name: String, role: Int, segments: String, sendActivation: Boolean): CreateUserPayload!
   CreateBulkDownload(input: mutationInput_CreateBulkDownload_input_Input): JSON @httpOperation(path: "/bulk_download", httpMethod: POST)
   DeleteSamples(input: mutationInput_DeleteSamples_input_Input): DeleteSamples @httpOperation(path: "/samples/bulk_delete", httpMethod: POST)
   UpdateSampleNotes(sampleId: String, input: mutationInput_UpdateSampleNotes_input_Input): UpdateSampleNotes @httpOperation(path: "/samples/{args.sampleId}/save_metadata", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
@@ -129,6 +129,371 @@ type Mutation {
   KickoffWGSWorkflow(sampleId: String, input: mutationInput_KickoffWGSWorkflow_input_Input): [mutation_KickoffWGSWorkflow_items] @httpOperation(path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   KickoffAMRWorkflow(sampleId: String, input: mutationInput_KickoffAMRWorkflow_input_Input): [mutation_KickoffWGSWorkflow_items] @httpOperation(path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   UpdateMetadata(sampleId: String, input: mutationInput_UpdateMetadata_input_Input): UpdateMetadataReponse @httpOperation(path: "/samples/{args.sampleId}/save_metadata_v2", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
+}
+
+type AlignmentConfig {
+  createdAt: ISO8601DateTime!
+  indexDirSuffix: String
+  lineageVersion: String!
+  lineageVersionOld: Int
+  name: String
+  s3Accession2taxidPath: String
+  s3DeuterostomeDbPath: String
+  s3LineagePath: String
+  s3NrDbPath: String
+  s3NrLocDbPath: String
+  s3NtDbPath: String
+  s3NtInfoDbPath: String
+  s3NtLocDbPath: String
+  s3TaxonBlacklistPath: String
+  updatedAt: ISO8601DateTime!
+}
+
+input Annotation {
+  name: String!
+}
+
+type AppConfig {
+  key: String!
+  value: String!
+}
+
+"""
+Represents non-fractional signed whole numeric values. Since the value may
+exceed the size of a 32-bit integer, it's encoded as a string.
+"""
+scalar BigInt
+
+"""Autogenerated return type of CreateUser."""
+type CreateUserPayload {
+  archetypes: String
+  email: String
+  institution: String
+  name: String
+  role: Int
+  segments: String
+  sendActivation: Boolean
+}
+
+type DbSample {
+  alignmentConfigName: String
+  basespaceAccessToken: String
+  clientUpdatedAt: ISO8601DateTime
+  createdAt: ISO8601DateTime!
+  dagVars: String
+  doNotProcess: Boolean!
+  hostGenomeId: Int
+  hostGenomeName: String
+  id: Int!
+  initialWorkflow: String!
+  inputFiles: [InputFile!]!
+  maxInputFragments: Int
+  name: String
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  privateUntil: ISO8601DateTime
+  projectId: Int
+  s3Bowtie2IndexPath: String
+  s3PreloadResultPath: String
+  s3StarIndexPath: String
+  sampleNotes: String
+  status: String
+  subsample: Int
+  updatedAt: ISO8601DateTime!
+  uploadError: String
+  uploadedFromBasespace: Int!
+  useTaxonWhitelist: Boolean!
+  userId: Int!
+  webCommit: String
+}
+
+type DerivedSampleOutput {
+  hostGenomeName: String!
+  pipelineRun: PipelineRun
+  projectName: String!
+  summaryStats: SampleSummaryStats
+}
+
+type HostGenome {
+  createdAt: ISO8601DateTime!
+  defaultBackgroundId: Int
+  id: Int!
+  name: String!
+  s3Bowtie2IndexPath: String!
+  s3Minimap2IndexPath: String
+  s3StarIndexPath: String!
+  samplesCount: Int!
+  skipDeuteroFilter: Int!
+  taxaCategory: String!
+  updatedAt: ISO8601DateTime!
+  user: User
+  userId: Int
+}
+
+"""An ISO 8601-encoded datetime"""
+scalar ISO8601DateTime
+
+type InputFile {
+  createdAt: ISO8601DateTime!
+  id: Int!
+  name: String
+  parts: String
+  presignedUrl: String
+  sampleId: Int!
+  source: String
+  sourceType: String
+  updatedAt: ISO8601DateTime
+  uploadClient: String
+}
+
+type MngsRunInfo {
+  createdAt: ISO8601DateTime
+  finalized: Int
+  reportReady: Boolean
+  resultStatusDescription: String
+  totalRuntime: Int
+  withAssembly: Int
+}
+
+type Pathogen {
+  category: String
+  name: String
+  taxId: Int
+}
+
+type PathogenList {
+  citations: [String!]
+  createdAt: ISO8601DateTime
+  id: ID
+  name: String
+  pathogens: [Pathogen!]
+  updatedAt: ISO8601DateTime
+  version: String
+}
+
+type PipelineRun {
+  adjustedRemainingReads: Int
+  alertSent: Boolean!
+  alignmentConfig: AlignmentConfig
+  alignmentConfigId: Int
+  alignmentConfigName: String
+  assembled: Int
+  compressionRatio: Float
+  createdAt: ISO8601DateTime
+  dagVars: String
+  deprecated: Boolean
+  errorMessage: String
+  executedAt: ISO8601DateTime
+  finalized: Int
+  fractionSubsampled: Float
+  id: Int!
+  jobStatus: String
+  knownUserError: String
+  maxInputFragments: Int
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  pipelineVersion: String
+  qcPercent: Float
+  resultsFinalized: Int
+  s3OutputPrefix: String
+  sampleId: Int
+  sfnExecutionArn: String
+  subsample: Int
+  timeToFinalized: Int
+  timeToResultsFinalized: Int
+  totalErccReads: Int
+  totalReads: Int
+  truncated: Int
+  unmappedReads: Int
+  updatedAt: ISO8601DateTime!
+  useTaxonWhitelist: Boolean!
+  wdlVersion: String
+}
+
+type Project {
+  backgroundFlag: Int
+  createdAt: ISO8601DateTime!
+  creator: User
+  daysToKeepSamplePrivate: Int!
+  description: String
+  id: Int!
+  maxInputFragmentsDefault: Int
+  name: String!
+  publicAccess: Int!
+  samples: [Sample!]
+  subsampleDefault: Int
+  totalSampleCount: Int!
+  updatedAt: ISO8601DateTime!
+}
+
+type Sample implements EntityInterface & Node {
+  alignmentConfigName: String
+  basespaceAccessToken: String
+  createdAt: ISO8601DateTime
+  dagVars: String
+  defaultBackgroundId: Int
+  defaultPipelineRunId: Int
+  details: SampleDetails!
+  doNotProcess: Boolean!
+  editable: Boolean
+  hostGenome: HostGenome
+  hostGenomeId: Int
+  id: ID!
+  initialWorkflow: String!
+  maxInputFragments: Int
+  name: String!
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  pipelineRuns: [PipelineRun!]
+  privateUntil: ISO8601DateTime
+  project: Project
+  projectId: Int
+  public: Int!
+  s3Bowtie2IndexPath: String
+  s3PreloadResultPath: String
+  s3StarIndexPath: String
+  sampleDeletable: Boolean
+  sampleNotes: String
+  status: String
+  subsample: Int
+  updatedAt: ISO8601DateTime
+  uploadError: String
+  uploadedFromBasespace: Int
+  useTaxonWhitelist: Boolean!
+  user: User
+  userId: Int
+  webCommit: String
+  workflowRuns: [WorkflowRun!]
+  """The Globally Unique ID of this object"""
+  _id: GlobalID!
+  producingRunId: Int
+  ownerUserId: Int!
+  collectionId: Int!
+  sampleType: String!
+  waterControl: Boolean!
+  collectionDate: DateTime
+  collectionLocation: String!
+  description: String
+  hostTaxon(where: TaxonWhereClause = null): Taxon
+  sequencingReads(
+    where: SequencingReadWhereClause = null
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+    """Returns the first n items from the list."""
+    first: Int = null
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): SequencingReadConnection!
+  sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
+  metadatas(
+    where: MetadatumWhereClause = null
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+    """Returns the first n items from the list."""
+    first: Int = null
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MetadatumConnection!
+  metadatasAggregate(where: MetadatumWhereClause = null): MetadatumAggregate
+}
+
+type SampleDetails {
+  dbSample: DbSample
+  derivedSampleOutput: DerivedSampleOutput
+  metadata: SampleMetadata
+  mngsRunInfo: MngsRunInfo
+  uploader: SampleUploader!
+  workflowRunsCountByWorkflow: String
+}
+
+type SampleList {
+  sampleIds: [Int!]
+  samples: [Sample!]!
+}
+
+type SampleMetadata {
+  collectionDate: String
+  collectionLocationV2: String
+  nucleotideType: String
+  sampleType: String
+  waterControl: String
+  metadata: [query_SampleMetadata_metadata_items]
+  additional_info: query_SampleMetadata_additional_info
+}
+
+type SampleReadsStats {
+  initialReads: Int
+  name: String
+  pipelineVersion: String
+  sampleId: ID!
+  steps: [SampleSteps!]
+  wdlVersion: String
+}
+
+type SampleReadsStatsList {
+  sampleReadsStats: [SampleReadsStats!]!
+}
+
+type SampleSteps {
+  name: String
+  readsAfter: Int
+}
+
+type SampleSummaryStats {
+  adjustedRemainingReads: Int
+  compressionRatio: Float
+  insertSizeMean: Float
+  insertSizeStandardDeviation: Float
+  lastProcessedAt: ISO8601DateTime
+  percentRemaining: Float
+  qcPercent: Float
+  readsAfterCzidDedup: Int
+  readsAfterPriceseq: Int
+  readsAfterStar: Int
+  readsAfterTrimmomatic: Int
+  unmappedReads: Int
+}
+
+type SampleUploader {
+  id: Int!
+  name: String
+}
+
+type User {
+  archetypes: String!
+  createdByUserId: BigInt!
+  email: String!
+  id: ID!
+  institution: String!
+  name: String!
+  role: Int!
+  segments: String!
+}
+
+type WorkflowRun {
+  cachedResults: String
+  createdAt: ISO8601DateTime!
+  deprecated: Boolean!
+  errorMessage: String
+  executedAt: ISO8601DateTime
+  inputsJson: String
+  rerunFrom: Int
+  s3OutputPrefix: String
+  sample: Sample
+  sampleId: Int
+  sfnExecutionArn: String
+  status: String!
+  timeToFinalized: Int
+  updatedAt: ISO8601DateTime!
+  wdlVersion: String
+  workflow: String!
 }
 
 enum AlignmentTool {
@@ -1158,82 +1523,6 @@ input ReferenceGenomeWhereClauseMutations {
   id: UUIDComparators
 }
 
-type Sample implements EntityInterface & Node {
-  """The Globally Unique ID of this object"""
-  _id: GlobalID!
-  id: ID!
-  producingRunId: Int
-  ownerUserId: Int!
-  collectionId: Int!
-  name: String!
-  sampleType: String!
-  waterControl: Boolean!
-  collectionDate: DateTime
-  collectionLocation: String!
-  description: String
-  hostTaxon(where: TaxonWhereClause = null): Taxon
-  sequencingReads(
-    where: SequencingReadWhereClause = null
-    """Returns the items in the list that come before the specified cursor."""
-    before: String = null
-    """Returns the items in the list that come after the specified cursor."""
-    after: String = null
-    """Returns the first n items from the list."""
-    first: Int = null
-    """Returns the items in the list that come after the specified cursor."""
-    last: Int = null
-  ): SequencingReadConnection!
-  sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
-  metadatas(
-    where: MetadatumWhereClause = null
-    """Returns the items in the list that come before the specified cursor."""
-    before: String = null
-    """Returns the items in the list that come after the specified cursor."""
-    after: String = null
-    """Returns the first n items from the list."""
-    first: Int = null
-    """Returns the items in the list that come after the specified cursor."""
-    last: Int = null
-  ): MetadatumConnection!
-  metadatasAggregate(where: MetadatumWhereClause = null): MetadatumAggregate
-  alignmentConfigName: String
-  basespaceAccessToken: String
-  createdAt: ISO8601DateTime
-  dagVars: String
-  defaultBackgroundId: Int
-  defaultPipelineRunId: Int
-  details: SampleDetails!
-  doNotProcess: Boolean!
-  editable: Boolean
-  hostGenome: HostGenome
-  hostGenomeId: Int
-  initialWorkflow: String!
-  maxInputFragments: Int
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  pipelineRuns: [PipelineRun!]
-  privateUntil: ISO8601DateTime
-  project: Project
-  projectId: Int
-  public: Int!
-  s3Bowtie2IndexPath: String
-  s3PreloadResultPath: String
-  s3StarIndexPath: String
-  sampleDeletable: Boolean
-  sampleNotes: String
-  status: String
-  subsample: Int
-  updatedAt: ISO8601DateTime
-  uploadError: String
-  uploadedFromBasespace: Int
-  useTaxonWhitelist: Boolean!
-  user: User
-  userId: Int
-  webCommit: String
-  workflowRuns: [WorkflowRun!]
-}
-
 type SampleAggregate {
   aggregate: SampleAggregateFunctions
 }
@@ -1970,295 +2259,6 @@ input UpstreamDatabaseWhereClauseMutations {
   id: UUIDComparators
 }
 
-type AlignmentConfig {
-  createdAt: ISO8601DateTime!
-  indexDirSuffix: String
-  lineageVersion: String!
-  lineageVersionOld: Int
-  name: String
-  s3Accession2taxidPath: String
-  s3DeuterostomeDbPath: String
-  s3LineagePath: String
-  s3NrDbPath: String
-  s3NrLocDbPath: String
-  s3NtDbPath: String
-  s3NtInfoDbPath: String
-  s3NtLocDbPath: String
-  s3TaxonBlacklistPath: String
-  updatedAt: ISO8601DateTime!
-}
-
-input Annotation {
-  name: String!
-}
-
-type AppConfig {
-  key: String!
-  value: String!
-}
-
-"""
-Represents non-fractional signed whole numeric values. Since the value may
-exceed the size of a 32-bit integer, it's encoded as a string.
-"""
-scalar BigInt
-
-"""Autogenerated return type of CreateUser."""
-type CreateUserPayload {
-  archetypes: String
-  email: String
-  institution: String
-  name: String
-  role: Int
-  segments: String
-  sendActivation: Boolean
-}
-
-type DbSample {
-  alignmentConfigName: String
-  basespaceAccessToken: String
-  clientUpdatedAt: ISO8601DateTime
-  createdAt: ISO8601DateTime!
-  dagVars: String
-  doNotProcess: Boolean!
-  hostGenomeId: Int
-  hostGenomeName: String
-  id: Int!
-  initialWorkflow: String!
-  inputFiles: [InputFile!]!
-  maxInputFragments: Int
-  name: String
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  privateUntil: ISO8601DateTime
-  projectId: Int
-  s3Bowtie2IndexPath: String
-  s3PreloadResultPath: String
-  s3StarIndexPath: String
-  sampleNotes: String
-  status: String
-  subsample: Int
-  updatedAt: ISO8601DateTime!
-  uploadError: String
-  uploadedFromBasespace: Int!
-  useTaxonWhitelist: Boolean!
-  userId: Int!
-  webCommit: String
-}
-
-type DerivedSampleOutput {
-  hostGenomeName: String!
-  pipelineRun: PipelineRun
-  projectName: String!
-  summaryStats: SampleSummaryStats
-}
-
-type HostGenome {
-  createdAt: ISO8601DateTime!
-  defaultBackgroundId: Int
-  id: Int!
-  name: String!
-  s3Bowtie2IndexPath: String!
-  s3Minimap2IndexPath: String
-  s3StarIndexPath: String!
-  samplesCount: Int!
-  skipDeuteroFilter: Int!
-  taxaCategory: String!
-  updatedAt: ISO8601DateTime!
-  user: User
-  userId: Int
-}
-
-"""An ISO 8601-encoded datetime"""
-scalar ISO8601DateTime
-
-type InputFile {
-  createdAt: ISO8601DateTime!
-  id: Int!
-  name: String
-  parts: String
-  presignedUrl: String
-  sampleId: Int!
-  source: String
-  sourceType: String
-  updatedAt: ISO8601DateTime
-  uploadClient: String
-}
-
-type MngsRunInfo {
-  createdAt: ISO8601DateTime
-  finalized: Int
-  reportReady: Boolean
-  resultStatusDescription: String
-  totalRuntime: Int
-  withAssembly: Int
-}
-
-type Pathogen {
-  category: String
-  name: String
-  taxId: Int
-}
-
-type PathogenList {
-  citations: [String!]
-  createdAt: ISO8601DateTime
-  id: ID
-  name: String
-  pathogens: [Pathogen!]
-  updatedAt: ISO8601DateTime
-  version: String
-}
-
-type PipelineRun {
-  adjustedRemainingReads: Int
-  alertSent: Boolean!
-  alignmentConfig: AlignmentConfig
-  alignmentConfigId: Int
-  alignmentConfigName: String
-  assembled: Int
-  compressionRatio: Float
-  createdAt: ISO8601DateTime
-  dagVars: String
-  deprecated: Boolean
-  errorMessage: String
-  executedAt: ISO8601DateTime
-  finalized: Int
-  fractionSubsampled: Float
-  id: Int!
-  jobStatus: String
-  knownUserError: String
-  maxInputFragments: Int
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  pipelineVersion: String
-  qcPercent: Float
-  resultsFinalized: Int
-  s3OutputPrefix: String
-  sampleId: Int
-  sfnExecutionArn: String
-  subsample: Int
-  timeToFinalized: Int
-  timeToResultsFinalized: Int
-  totalErccReads: Int
-  totalReads: Int
-  truncated: Int
-  unmappedReads: Int
-  updatedAt: ISO8601DateTime!
-  useTaxonWhitelist: Boolean!
-  wdlVersion: String
-}
-
-type Project {
-  backgroundFlag: Int
-  createdAt: ISO8601DateTime!
-  creator: User
-  daysToKeepSamplePrivate: Int!
-  description: String
-  id: Int!
-  maxInputFragmentsDefault: Int
-  name: String!
-  publicAccess: Int!
-  samples: [Sample!]
-  subsampleDefault: Int
-  totalSampleCount: Int!
-  updatedAt: ISO8601DateTime!
-}
-
-type SampleDetails {
-  dbSample: DbSample
-  derivedSampleOutput: DerivedSampleOutput
-  metadata: SampleMetadata
-  mngsRunInfo: MngsRunInfo
-  uploader: SampleUploader!
-  workflowRunsCountByWorkflow: String
-}
-
-type SampleList {
-  sampleIds: [Int!]
-  samples: [Sample!]!
-}
-
-type SampleMetadata {
-  collectionDate: String
-  collectionLocationV2: String
-  nucleotideType: String
-  sampleType: String
-  waterControl: String
-  metadata: [query_SampleMetadata_metadata_items]
-  additional_info: query_SampleMetadata_additional_info
-}
-
-type SampleReadsStats {
-  initialReads: Int
-  name: String
-  pipelineVersion: String
-  sampleId: ID!
-  steps: [SampleSteps!]
-  wdlVersion: String
-}
-
-type SampleReadsStatsList {
-  sampleReadsStats: [SampleReadsStats!]!
-}
-
-type SampleSteps {
-  name: String
-  readsAfter: Int
-}
-
-type SampleSummaryStats {
-  adjustedRemainingReads: Int
-  compressionRatio: Float
-  insertSizeMean: Float
-  insertSizeStandardDeviation: Float
-  lastProcessedAt: ISO8601DateTime
-  percentRemaining: Float
-  qcPercent: Float
-  readsAfterCzidDedup: Int
-  readsAfterPriceseq: Int
-  readsAfterStar: Int
-  readsAfterTrimmomatic: Int
-  unmappedReads: Int
-}
-
-type SampleUploader {
-  id: Int!
-  name: String
-}
-
-type User {
-  archetypes: String!
-  createdByUserId: BigInt!
-  email: String!
-  id: ID!
-  institution: String!
-  name: String!
-  role: Int!
-  segments: String!
-}
-
-type WorkflowRun {
-  cachedResults: String
-  createdAt: ISO8601DateTime!
-  deprecated: Boolean!
-  errorMessage: String
-  executedAt: ISO8601DateTime
-  inputsJson: String
-  rerunFrom: Int
-  s3OutputPrefix: String
-  sample: Sample
-  sampleId: Int
-  sfnExecutionArn: String
-  status: String!
-  timeToFinalized: Int
-  updatedAt: ISO8601DateTime!
-  wdlVersion: String
-  workflow: String!
-}
-
 type AmrDeprecatedResults {
   id: Int
   gene: String
@@ -2395,7 +2395,7 @@ type query_consensusGenomes_items {
   producingRunId: String
   taxon: query_consensusGenomes_items_taxon
   referenceGenome: query_consensusGenomes_items_referenceGenome
-  metric: query_consensusGenomes_items_metric
+  metrics: query_consensusGenomes_items_metrics
   sequencingRead: query_consensusGenomes_items_sequencingRead
 }
 
@@ -2408,7 +2408,7 @@ type query_consensusGenomes_items_referenceGenome {
   accessionName: String
 }
 
-type query_consensusGenomes_items_metric {
+type query_consensusGenomes_items_metrics {
   coverageDepth: Float
   totalReads: Int
   gcPercent: Float
@@ -2441,6 +2441,7 @@ type query_consensusGenomes_items_sequencingRead_sample {
   collectionLocation: String!
   sampleType: String!
   waterControl: Boolean
+  uploadError: String
   hostOrganism: query_consensusGenomes_items_sequencingRead_sample_hostOrganism
   collection: query_consensusGenomes_items_sequencingRead_sample_collection
   ownerUser: query_consensusGenomes_items_sequencingRead_sample_ownerUser
@@ -2474,6 +2475,8 @@ type query_consensusGenomes_items_sequencingRead_sample_metadatas_edges_items_no
 }
 
 input queryInput_consensusGenomes_input_Input {
+  limit: Int
+  offset: Int
   where: queryInput_consensusGenomes_input_where_Input
   orderBy: queryInput_consensusGenomes_input_orderBy_Input
   todoRemove: queryInput_consensusGenomes_input_todoRemove_Input
@@ -2523,8 +2526,6 @@ input queryInput_consensusGenomes_input_todoRemove_Input {
   tissue: [String]
   orderBy: String
   orderDir: String
-  offset: Int
-  limit: Int
 }
 
 type ConsensusGenomeWorkflowResults {
@@ -3003,6 +3004,7 @@ type query_sequencingReads_items_sample {
   collectionLocation: String!
   sampleType: String!
   waterControl: Boolean
+  uploadError: String
   hostOrganism: query_sequencingReads_items_sample_hostOrganism
   collection: query_sequencingReads_items_sample_collection
   ownerUser: query_sequencingReads_items_sample_ownerUser
@@ -3047,7 +3049,7 @@ type query_sequencingReads_items_consensusGenomes_edges_items_node {
   producingRunId: String
   taxon: query_sequencingReads_items_consensusGenomes_edges_items_node_taxon
   referenceGenome: query_sequencingReads_items_consensusGenomes_edges_items_node_referenceGenome
-  metric: query_sequencingReads_items_consensusGenomes_edges_items_node_metric
+  metrics: query_sequencingReads_items_consensusGenomes_edges_items_node_metrics
 }
 
 type query_sequencingReads_items_consensusGenomes_edges_items_node_taxon {
@@ -3059,7 +3061,7 @@ type query_sequencingReads_items_consensusGenomes_edges_items_node_referenceGeno
   accessionName: String
 }
 
-type query_sequencingReads_items_consensusGenomes_edges_items_node_metric {
+type query_sequencingReads_items_consensusGenomes_edges_items_node_metrics {
   coverageDepth: Float
   totalReads: Int
   gcPercent: Float
@@ -3073,6 +3075,8 @@ type query_sequencingReads_items_consensusGenomes_edges_items_node_metric {
 }
 
 input queryInput_sequencingReads_input_Input {
+  limit: Int
+  offset: Int
   where: queryInput_sequencingReads_input_where_Input
   orderBy: queryInput_sequencingReads_input_orderBy_Input
   consensusGenomesInput: queryInput_sequencingReads_input_consensusGenomesInput_Input
@@ -3140,8 +3144,6 @@ input queryInput_sequencingReads_input_todoRemove_Input {
   tissue: [String]
   orderBy: String
   orderDir: String
-  offset: Int
-  limit: Int
 }
 
 type query_Taxons_items {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -2444,7 +2444,8 @@ type query_consensusGenomes_items_sequencingRead_sample {
   uploadError: String
   hostOrganism: query_consensusGenomes_items_sequencingRead_sample_hostOrganism
   collection: query_consensusGenomes_items_sequencingRead_sample_collection
-  ownerUser: query_consensusGenomes_items_sequencingRead_sample_ownerUser
+  ownerUserId: Float
+  ownerUserName: String
   metadatas: query_consensusGenomes_items_sequencingRead_sample_metadatas!
 }
 
@@ -2455,10 +2456,6 @@ type query_consensusGenomes_items_sequencingRead_sample_hostOrganism {
 type query_consensusGenomes_items_sequencingRead_sample_collection {
   name: String
   public: Boolean
-}
-
-type query_consensusGenomes_items_sequencingRead_sample_ownerUser {
-  name: String
 }
 
 type query_consensusGenomes_items_sequencingRead_sample_metadatas {
@@ -3007,7 +3004,8 @@ type query_sequencingReads_items_sample {
   uploadError: String
   hostOrganism: query_sequencingReads_items_sample_hostOrganism
   collection: query_sequencingReads_items_sample_collection
-  ownerUser: query_sequencingReads_items_sample_ownerUser
+  ownerUserId: Float
+  ownerUserName: String
   metadatas: query_sequencingReads_items_sample_metadatas!
 }
 
@@ -3018,10 +3016,6 @@ type query_sequencingReads_items_sample_hostOrganism {
 type query_sequencingReads_items_sample_collection {
   name: String
   public: Boolean
-}
-
-type query_sequencingReads_items_sample_ownerUser {
-  name: String
 }
 
 type query_sequencingReads_items_sample_metadatas {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -17,13 +17,6 @@ directive @globalOptions(sourceName: String, endpoint: String, operationHeaders:
 directive @httpOperation(path: String, operationSpecificHeaders: ObjMap, httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap) on FIELD_DEFINITION
 
 type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") {
-  appConfig(id: ID!): AppConfig
-  pathogenList(version: String): PathogenList!
-  project(id: Int!): Project!
-  sample(sampleId: Int!): Sample!
-  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
-  samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
-  user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
   node(
     """The ID of the object."""
     id: GlobalID!
@@ -55,6 +48,13 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   upstreamDatabasesAggregate(where: UpstreamDatabaseWhereClause = null): UpstreamDatabaseAggregate!
   contigsAggregate(where: ContigWhereClause = null): ContigAggregate!
   phylogeneticTreesAggregate(where: PhylogeneticTreeWhereClause = null): PhylogeneticTreeAggregate!
+  appConfig(id: ID!): AppConfig
+  pathogenList(version: String): PathogenList!
+  project(id: Int!): Project!
+  sample(sampleId: Int!): Sample!
+  sampleReadsStats(sampleIds: [String!]!): SampleReadsStatsList!
+  samplesList(annotations: [Annotation!], basic: Boolean, domain: String, hostIds: [Int!], limit: Int, listAllIds: Boolean, location: String, locationV2: [String!], offset: Int, orderBy: String, orderDir: String, projectId: Int, requestedSampleIds: [Int!], sampleIds: [Int!], searchString: String, taxIds: [Int!], taxLevels: [String!], thresholdFilterInfo: String, time: [String!], tissue: [String!], visibility: [String!], workflow: String): SampleList!
+  user(archetypes: String!, email: String!, institution: String!, name: String!, role: Int!, segments: String!): User!
   AmrDeprecatedResults(sampleId: String): AmrDeprecatedResults @httpOperation(path: "/samples/{args.sampleId}/amr.json", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   AmrWorkflowResults(workflowRunId: String): AmrWorkflowResults @httpOperation(path: "/workflow_runs/{args.workflowRunId}/results", httpMethod: GET)
   Background(snapshotLinkId: String): Background @httpOperation(path: "/pub/{args.snapshotLinkId}/backgrounds.json", httpMethod: GET)
@@ -81,7 +81,6 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
 }
 
 type Mutation {
-  createUser(archetypes: String, email: String!, institution: String, name: String, role: Int, segments: String, sendActivation: Boolean): CreateUserPayload!
   createFile(entityId: ID!, entityFieldName: String!, file: FileCreate!): File!
   uploadFile(entityId: ID!, entityFieldName: String!, file: FileUpload!, expiration: Int! = 3600): MultipartUploadResponse!
   markUploadComplete(fileId: ID!): File!
@@ -122,6 +121,7 @@ type Mutation {
   createPhylogeneticTree(input: PhylogeneticTreeCreateInput!): PhylogeneticTree!
   updatePhylogeneticTree(input: PhylogeneticTreeUpdateInput!, where: PhylogeneticTreeWhereClauseMutations!): [PhylogeneticTree!]!
   deletePhylogeneticTree(where: PhylogeneticTreeWhereClauseMutations!): [PhylogeneticTree!]!
+  createUser(archetypes: String, email: String!, institution: String, name: String, role: Int, segments: String, sendActivation: Boolean): CreateUserPayload!
   CreateBulkDownload(input: mutationInput_CreateBulkDownload_input_Input): JSON @httpOperation(path: "/bulk_download", httpMethod: POST)
   DeleteSamples(input: mutationInput_DeleteSamples_input_Input): DeleteSamples @httpOperation(path: "/samples/bulk_delete", httpMethod: POST)
   UpdateSampleNotes(sampleId: String, input: mutationInput_UpdateSampleNotes_input_Input): UpdateSampleNotes @httpOperation(path: "/samples/{args.sampleId}/save_metadata", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
@@ -129,371 +129,6 @@ type Mutation {
   KickoffWGSWorkflow(sampleId: String, input: mutationInput_KickoffWGSWorkflow_input_Input): [mutation_KickoffWGSWorkflow_items] @httpOperation(path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   KickoffAMRWorkflow(sampleId: String, input: mutationInput_KickoffAMRWorkflow_input_Input): [mutation_KickoffWGSWorkflow_items] @httpOperation(path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   UpdateMetadata(sampleId: String, input: mutationInput_UpdateMetadata_input_Input): UpdateMetadataReponse @httpOperation(path: "/samples/{args.sampleId}/save_metadata_v2", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
-}
-
-type AlignmentConfig {
-  createdAt: ISO8601DateTime!
-  indexDirSuffix: String
-  lineageVersion: String!
-  lineageVersionOld: Int
-  name: String
-  s3Accession2taxidPath: String
-  s3DeuterostomeDbPath: String
-  s3LineagePath: String
-  s3NrDbPath: String
-  s3NrLocDbPath: String
-  s3NtDbPath: String
-  s3NtInfoDbPath: String
-  s3NtLocDbPath: String
-  s3TaxonBlacklistPath: String
-  updatedAt: ISO8601DateTime!
-}
-
-input Annotation {
-  name: String!
-}
-
-type AppConfig {
-  key: String!
-  value: String!
-}
-
-"""
-Represents non-fractional signed whole numeric values. Since the value may
-exceed the size of a 32-bit integer, it's encoded as a string.
-"""
-scalar BigInt
-
-"""Autogenerated return type of CreateUser."""
-type CreateUserPayload {
-  archetypes: String
-  email: String
-  institution: String
-  name: String
-  role: Int
-  segments: String
-  sendActivation: Boolean
-}
-
-type DbSample {
-  alignmentConfigName: String
-  basespaceAccessToken: String
-  clientUpdatedAt: ISO8601DateTime
-  createdAt: ISO8601DateTime!
-  dagVars: String
-  doNotProcess: Boolean!
-  hostGenomeId: Int
-  hostGenomeName: String
-  id: Int!
-  initialWorkflow: String!
-  inputFiles: [InputFile!]!
-  maxInputFragments: Int
-  name: String
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  privateUntil: ISO8601DateTime
-  projectId: Int
-  s3Bowtie2IndexPath: String
-  s3PreloadResultPath: String
-  s3StarIndexPath: String
-  sampleNotes: String
-  status: String
-  subsample: Int
-  updatedAt: ISO8601DateTime!
-  uploadError: String
-  uploadedFromBasespace: Int!
-  useTaxonWhitelist: Boolean!
-  userId: Int!
-  webCommit: String
-}
-
-type DerivedSampleOutput {
-  hostGenomeName: String!
-  pipelineRun: PipelineRun
-  projectName: String!
-  summaryStats: SampleSummaryStats
-}
-
-type HostGenome {
-  createdAt: ISO8601DateTime!
-  defaultBackgroundId: Int
-  id: Int!
-  name: String!
-  s3Bowtie2IndexPath: String!
-  s3Minimap2IndexPath: String
-  s3StarIndexPath: String!
-  samplesCount: Int!
-  skipDeuteroFilter: Int!
-  taxaCategory: String!
-  updatedAt: ISO8601DateTime!
-  user: User
-  userId: Int
-}
-
-"""An ISO 8601-encoded datetime"""
-scalar ISO8601DateTime
-
-type InputFile {
-  createdAt: ISO8601DateTime!
-  id: Int!
-  name: String
-  parts: String
-  presignedUrl: String
-  sampleId: Int!
-  source: String
-  sourceType: String
-  updatedAt: ISO8601DateTime
-  uploadClient: String
-}
-
-type MngsRunInfo {
-  createdAt: ISO8601DateTime
-  finalized: Int
-  reportReady: Boolean
-  resultStatusDescription: String
-  totalRuntime: Int
-  withAssembly: Int
-}
-
-type Pathogen {
-  category: String
-  name: String
-  taxId: Int
-}
-
-type PathogenList {
-  citations: [String!]
-  createdAt: ISO8601DateTime
-  id: ID
-  name: String
-  pathogens: [Pathogen!]
-  updatedAt: ISO8601DateTime
-  version: String
-}
-
-type PipelineRun {
-  adjustedRemainingReads: Int
-  alertSent: Boolean!
-  alignmentConfig: AlignmentConfig
-  alignmentConfigId: Int
-  alignmentConfigName: String
-  assembled: Int
-  compressionRatio: Float
-  createdAt: ISO8601DateTime
-  dagVars: String
-  deprecated: Boolean
-  errorMessage: String
-  executedAt: ISO8601DateTime
-  finalized: Int
-  fractionSubsampled: Float
-  id: Int!
-  jobStatus: String
-  knownUserError: String
-  maxInputFragments: Int
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  pipelineVersion: String
-  qcPercent: Float
-  resultsFinalized: Int
-  s3OutputPrefix: String
-  sampleId: Int
-  sfnExecutionArn: String
-  subsample: Int
-  timeToFinalized: Int
-  timeToResultsFinalized: Int
-  totalErccReads: Int
-  totalReads: Int
-  truncated: Int
-  unmappedReads: Int
-  updatedAt: ISO8601DateTime!
-  useTaxonWhitelist: Boolean!
-  wdlVersion: String
-}
-
-type Project {
-  backgroundFlag: Int
-  createdAt: ISO8601DateTime!
-  creator: User
-  daysToKeepSamplePrivate: Int!
-  description: String
-  id: Int!
-  maxInputFragmentsDefault: Int
-  name: String!
-  publicAccess: Int!
-  samples: [Sample!]
-  subsampleDefault: Int
-  totalSampleCount: Int!
-  updatedAt: ISO8601DateTime!
-}
-
-type Sample implements EntityInterface & Node {
-  alignmentConfigName: String
-  basespaceAccessToken: String
-  createdAt: ISO8601DateTime
-  dagVars: String
-  defaultBackgroundId: Int
-  defaultPipelineRunId: Int
-  details: SampleDetails!
-  doNotProcess: Boolean!
-  editable: Boolean
-  hostGenome: HostGenome
-  hostGenomeId: Int
-  id: ID!
-  initialWorkflow: String!
-  maxInputFragments: Int
-  name: String!
-  pipelineBranch: String
-  pipelineCommit: String
-  pipelineExecutionStrategy: String
-  pipelineRuns: [PipelineRun!]
-  privateUntil: ISO8601DateTime
-  project: Project
-  projectId: Int
-  public: Int!
-  s3Bowtie2IndexPath: String
-  s3PreloadResultPath: String
-  s3StarIndexPath: String
-  sampleDeletable: Boolean
-  sampleNotes: String
-  status: String
-  subsample: Int
-  updatedAt: ISO8601DateTime
-  uploadError: String
-  uploadedFromBasespace: Int
-  useTaxonWhitelist: Boolean!
-  user: User
-  userId: Int
-  webCommit: String
-  workflowRuns: [WorkflowRun!]
-  """The Globally Unique ID of this object"""
-  _id: GlobalID!
-  producingRunId: Int
-  ownerUserId: Int!
-  collectionId: Int!
-  sampleType: String!
-  waterControl: Boolean!
-  collectionDate: DateTime
-  collectionLocation: String!
-  description: String
-  hostTaxon(where: TaxonWhereClause = null): Taxon
-  sequencingReads(
-    where: SequencingReadWhereClause = null
-    """Returns the items in the list that come before the specified cursor."""
-    before: String = null
-    """Returns the items in the list that come after the specified cursor."""
-    after: String = null
-    """Returns the first n items from the list."""
-    first: Int = null
-    """Returns the items in the list that come after the specified cursor."""
-    last: Int = null
-  ): SequencingReadConnection!
-  sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
-  metadatas(
-    where: MetadatumWhereClause = null
-    """Returns the items in the list that come before the specified cursor."""
-    before: String = null
-    """Returns the items in the list that come after the specified cursor."""
-    after: String = null
-    """Returns the first n items from the list."""
-    first: Int = null
-    """Returns the items in the list that come after the specified cursor."""
-    last: Int = null
-  ): MetadatumConnection!
-  metadatasAggregate(where: MetadatumWhereClause = null): MetadatumAggregate
-}
-
-type SampleDetails {
-  dbSample: DbSample
-  derivedSampleOutput: DerivedSampleOutput
-  metadata: SampleMetadata
-  mngsRunInfo: MngsRunInfo
-  uploader: SampleUploader!
-  workflowRunsCountByWorkflow: String
-}
-
-type SampleList {
-  sampleIds: [Int!]
-  samples: [Sample!]!
-}
-
-type SampleMetadata {
-  collectionDate: String
-  collectionLocationV2: String
-  nucleotideType: String
-  sampleType: String
-  waterControl: String
-  metadata: [query_SampleMetadata_metadata_items]
-  additional_info: query_SampleMetadata_additional_info
-}
-
-type SampleReadsStats {
-  initialReads: Int
-  name: String
-  pipelineVersion: String
-  sampleId: ID!
-  steps: [SampleSteps!]
-  wdlVersion: String
-}
-
-type SampleReadsStatsList {
-  sampleReadsStats: [SampleReadsStats!]!
-}
-
-type SampleSteps {
-  name: String
-  readsAfter: Int
-}
-
-type SampleSummaryStats {
-  adjustedRemainingReads: Int
-  compressionRatio: Float
-  insertSizeMean: Float
-  insertSizeStandardDeviation: Float
-  lastProcessedAt: ISO8601DateTime
-  percentRemaining: Float
-  qcPercent: Float
-  readsAfterCzidDedup: Int
-  readsAfterPriceseq: Int
-  readsAfterStar: Int
-  readsAfterTrimmomatic: Int
-  unmappedReads: Int
-}
-
-type SampleUploader {
-  id: Int!
-  name: String
-}
-
-type User {
-  archetypes: String!
-  createdByUserId: BigInt!
-  email: String!
-  id: ID!
-  institution: String!
-  name: String!
-  role: Int!
-  segments: String!
-}
-
-type WorkflowRun {
-  cachedResults: String
-  createdAt: ISO8601DateTime!
-  deprecated: Boolean!
-  errorMessage: String
-  executedAt: ISO8601DateTime
-  inputsJson: String
-  rerunFrom: Int
-  s3OutputPrefix: String
-  sample: Sample
-  sampleId: Int
-  sfnExecutionArn: String
-  status: String!
-  timeToFinalized: Int
-  updatedAt: ISO8601DateTime!
-  wdlVersion: String
-  workflow: String!
 }
 
 enum AlignmentTool {
@@ -1523,6 +1158,82 @@ input ReferenceGenomeWhereClauseMutations {
   id: UUIDComparators
 }
 
+type Sample implements EntityInterface & Node {
+  """The Globally Unique ID of this object"""
+  _id: GlobalID!
+  id: ID!
+  producingRunId: Int
+  ownerUserId: Int!
+  collectionId: Int!
+  name: String!
+  sampleType: String!
+  waterControl: Boolean!
+  collectionDate: DateTime
+  collectionLocation: String!
+  description: String
+  hostTaxon(where: TaxonWhereClause = null): Taxon
+  sequencingReads(
+    where: SequencingReadWhereClause = null
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+    """Returns the first n items from the list."""
+    first: Int = null
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): SequencingReadConnection!
+  sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
+  metadatas(
+    where: MetadatumWhereClause = null
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+    """Returns the first n items from the list."""
+    first: Int = null
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MetadatumConnection!
+  metadatasAggregate(where: MetadatumWhereClause = null): MetadatumAggregate
+  alignmentConfigName: String
+  basespaceAccessToken: String
+  createdAt: ISO8601DateTime
+  dagVars: String
+  defaultBackgroundId: Int
+  defaultPipelineRunId: Int
+  details: SampleDetails!
+  doNotProcess: Boolean!
+  editable: Boolean
+  hostGenome: HostGenome
+  hostGenomeId: Int
+  initialWorkflow: String!
+  maxInputFragments: Int
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  pipelineRuns: [PipelineRun!]
+  privateUntil: ISO8601DateTime
+  project: Project
+  projectId: Int
+  public: Int!
+  s3Bowtie2IndexPath: String
+  s3PreloadResultPath: String
+  s3StarIndexPath: String
+  sampleDeletable: Boolean
+  sampleNotes: String
+  status: String
+  subsample: Int
+  updatedAt: ISO8601DateTime
+  uploadError: String
+  uploadedFromBasespace: Int
+  useTaxonWhitelist: Boolean!
+  user: User
+  userId: Int
+  webCommit: String
+  workflowRuns: [WorkflowRun!]
+}
+
 type SampleAggregate {
   aggregate: SampleAggregateFunctions
 }
@@ -2257,6 +1968,295 @@ input UpstreamDatabaseWhereClause {
 
 input UpstreamDatabaseWhereClauseMutations {
   id: UUIDComparators
+}
+
+type AlignmentConfig {
+  createdAt: ISO8601DateTime!
+  indexDirSuffix: String
+  lineageVersion: String!
+  lineageVersionOld: Int
+  name: String
+  s3Accession2taxidPath: String
+  s3DeuterostomeDbPath: String
+  s3LineagePath: String
+  s3NrDbPath: String
+  s3NrLocDbPath: String
+  s3NtDbPath: String
+  s3NtInfoDbPath: String
+  s3NtLocDbPath: String
+  s3TaxonBlacklistPath: String
+  updatedAt: ISO8601DateTime!
+}
+
+input Annotation {
+  name: String!
+}
+
+type AppConfig {
+  key: String!
+  value: String!
+}
+
+"""
+Represents non-fractional signed whole numeric values. Since the value may
+exceed the size of a 32-bit integer, it's encoded as a string.
+"""
+scalar BigInt
+
+"""Autogenerated return type of CreateUser."""
+type CreateUserPayload {
+  archetypes: String
+  email: String
+  institution: String
+  name: String
+  role: Int
+  segments: String
+  sendActivation: Boolean
+}
+
+type DbSample {
+  alignmentConfigName: String
+  basespaceAccessToken: String
+  clientUpdatedAt: ISO8601DateTime
+  createdAt: ISO8601DateTime!
+  dagVars: String
+  doNotProcess: Boolean!
+  hostGenomeId: Int
+  hostGenomeName: String
+  id: Int!
+  initialWorkflow: String!
+  inputFiles: [InputFile!]!
+  maxInputFragments: Int
+  name: String
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  privateUntil: ISO8601DateTime
+  projectId: Int
+  s3Bowtie2IndexPath: String
+  s3PreloadResultPath: String
+  s3StarIndexPath: String
+  sampleNotes: String
+  status: String
+  subsample: Int
+  updatedAt: ISO8601DateTime!
+  uploadError: String
+  uploadedFromBasespace: Int!
+  useTaxonWhitelist: Boolean!
+  userId: Int!
+  webCommit: String
+}
+
+type DerivedSampleOutput {
+  hostGenomeName: String!
+  pipelineRun: PipelineRun
+  projectName: String!
+  summaryStats: SampleSummaryStats
+}
+
+type HostGenome {
+  createdAt: ISO8601DateTime!
+  defaultBackgroundId: Int
+  id: Int!
+  name: String!
+  s3Bowtie2IndexPath: String!
+  s3Minimap2IndexPath: String
+  s3StarIndexPath: String!
+  samplesCount: Int!
+  skipDeuteroFilter: Int!
+  taxaCategory: String!
+  updatedAt: ISO8601DateTime!
+  user: User
+  userId: Int
+}
+
+"""An ISO 8601-encoded datetime"""
+scalar ISO8601DateTime
+
+type InputFile {
+  createdAt: ISO8601DateTime!
+  id: Int!
+  name: String
+  parts: String
+  presignedUrl: String
+  sampleId: Int!
+  source: String
+  sourceType: String
+  updatedAt: ISO8601DateTime
+  uploadClient: String
+}
+
+type MngsRunInfo {
+  createdAt: ISO8601DateTime
+  finalized: Int
+  reportReady: Boolean
+  resultStatusDescription: String
+  totalRuntime: Int
+  withAssembly: Int
+}
+
+type Pathogen {
+  category: String
+  name: String
+  taxId: Int
+}
+
+type PathogenList {
+  citations: [String!]
+  createdAt: ISO8601DateTime
+  id: ID
+  name: String
+  pathogens: [Pathogen!]
+  updatedAt: ISO8601DateTime
+  version: String
+}
+
+type PipelineRun {
+  adjustedRemainingReads: Int
+  alertSent: Boolean!
+  alignmentConfig: AlignmentConfig
+  alignmentConfigId: Int
+  alignmentConfigName: String
+  assembled: Int
+  compressionRatio: Float
+  createdAt: ISO8601DateTime
+  dagVars: String
+  deprecated: Boolean
+  errorMessage: String
+  executedAt: ISO8601DateTime
+  finalized: Int
+  fractionSubsampled: Float
+  id: Int!
+  jobStatus: String
+  knownUserError: String
+  maxInputFragments: Int
+  pipelineBranch: String
+  pipelineCommit: String
+  pipelineExecutionStrategy: String
+  pipelineVersion: String
+  qcPercent: Float
+  resultsFinalized: Int
+  s3OutputPrefix: String
+  sampleId: Int
+  sfnExecutionArn: String
+  subsample: Int
+  timeToFinalized: Int
+  timeToResultsFinalized: Int
+  totalErccReads: Int
+  totalReads: Int
+  truncated: Int
+  unmappedReads: Int
+  updatedAt: ISO8601DateTime!
+  useTaxonWhitelist: Boolean!
+  wdlVersion: String
+}
+
+type Project {
+  backgroundFlag: Int
+  createdAt: ISO8601DateTime!
+  creator: User
+  daysToKeepSamplePrivate: Int!
+  description: String
+  id: Int!
+  maxInputFragmentsDefault: Int
+  name: String!
+  publicAccess: Int!
+  samples: [Sample!]
+  subsampleDefault: Int
+  totalSampleCount: Int!
+  updatedAt: ISO8601DateTime!
+}
+
+type SampleDetails {
+  dbSample: DbSample
+  derivedSampleOutput: DerivedSampleOutput
+  metadata: SampleMetadata
+  mngsRunInfo: MngsRunInfo
+  uploader: SampleUploader!
+  workflowRunsCountByWorkflow: String
+}
+
+type SampleList {
+  sampleIds: [Int!]
+  samples: [Sample!]!
+}
+
+type SampleMetadata {
+  collectionDate: String
+  collectionLocationV2: String
+  nucleotideType: String
+  sampleType: String
+  waterControl: String
+  metadata: [query_SampleMetadata_metadata_items]
+  additional_info: query_SampleMetadata_additional_info
+}
+
+type SampleReadsStats {
+  initialReads: Int
+  name: String
+  pipelineVersion: String
+  sampleId: ID!
+  steps: [SampleSteps!]
+  wdlVersion: String
+}
+
+type SampleReadsStatsList {
+  sampleReadsStats: [SampleReadsStats!]!
+}
+
+type SampleSteps {
+  name: String
+  readsAfter: Int
+}
+
+type SampleSummaryStats {
+  adjustedRemainingReads: Int
+  compressionRatio: Float
+  insertSizeMean: Float
+  insertSizeStandardDeviation: Float
+  lastProcessedAt: ISO8601DateTime
+  percentRemaining: Float
+  qcPercent: Float
+  readsAfterCzidDedup: Int
+  readsAfterPriceseq: Int
+  readsAfterStar: Int
+  readsAfterTrimmomatic: Int
+  unmappedReads: Int
+}
+
+type SampleUploader {
+  id: Int!
+  name: String
+}
+
+type User {
+  archetypes: String!
+  createdByUserId: BigInt!
+  email: String!
+  id: ID!
+  institution: String!
+  name: String!
+  role: Int!
+  segments: String!
+}
+
+type WorkflowRun {
+  cachedResults: String
+  createdAt: ISO8601DateTime!
+  deprecated: Boolean!
+  errorMessage: String
+  executedAt: ISO8601DateTime
+  inputsJson: String
+  rerunFrom: Int
+  s3OutputPrefix: String
+  sample: Sample
+  sampleId: Int
+  sfnExecutionArn: String
+  status: String!
+  timeToFinalized: Int
+  updatedAt: ISO8601DateTime!
+  wdlVersion: String
+  workflow: String!
 }
 
 type AmrDeprecatedResults {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9400]

## Description

Adds limit/offset to paginated fields.

Adds a temporary `uploadError` field, which should actually be errors from R1 and R2 but that will be done later.

Notice I had to delete `sequencingReads` and `consensusGenomes` from entities-schema.graphql because their types conflict with the custom types defined in our JSON files. We're unable to use exactly the NextGen return types while things like projects and users haven't been migrated, those have to be custom fields in the schema that don't exist in NextGen. I tried reordering the sources in .meshrc.yml to see if I could get the custom schemas to override that way, but it didn't work.

Also added fallbacks for required GQL fields because the corresponding fields in Rails don't have great guarantees that they'll actually exist (and Mesh will throw if nothing is returned).

## Tests

Unused endpoints.


[CZID-9400]: https://czi-tech.atlassian.net/browse/CZID-9400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ