### PR TITLE
feat: Add fed prefix to a few fields

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -127,19 +127,19 @@ sources:
             headers:
               Cookie: "{context.headers['cookie']}"
           - type: Query
-            field: samples
+            field: fedSamples
             method: GET
             path: /workflow_runs.json
             requestSchema: ./json-schemas/samplesRequest.json
             responseSchema: ./json-schemas/samplesResponse.json
-            responseTypeName: samples
+            responseTypeName: fedSamples
           - type: Query
-            field: sequencingReads
+            field: fedSequencingReads
             method: GET
             path: /workflow_runs.json
             requestSchema: ./json-schemas/sequencingReadsRequest.json
             responseSchema: ./json-schemas/sequencingReadsResponse.json
-            responseTypeName: sequencingReads
+            responseTypeName: fedSequencingReads
           - type: Query
             field: Taxons
             path: /pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false
@@ -174,12 +174,12 @@ sources:
             requestSchema: ./json-schemas/workflowRunsRequest.json
             responseSchema: ./json-schemas/workflowRunsResponse.json
           - type: Query
-            field: workflowRunsAggregate
+            field: fedWorkflowRunsAggregate
             path: /projects.json
             method: GET
             requestSchema: ./json-schemas/workflowRunsAggregateRequest.json
             responseSchema: ./json-schemas/workflowRunsAggregateResponse.json
-            responseTypeName: workflowRunsAggregate
+            responseTypeName: fedWorkflowRunsAggregate
           - type: Query
             field: ZipLink
             path: /workflow_runs/{args.workflowRunId}/zip_link.json

--- a/example-queries/samples-query.graphql
+++ b/example-queries/samples-query.graphql
@@ -1,5 +1,5 @@
 query TestQuery {
-    samples(input: {
+    fedSamples(input: {
         where: {
             name: {
             _like: "abc",

--- a/example-queries/sequencing-reads-query.graphql
+++ b/example-queries/sequencing-reads-query.graphql
@@ -1,5 +1,5 @@
 query TestQuery {
-    sequencingReads(input: {
+    fedSequencingReads(input: {
         limit: 50
         offset: 100
         where: {

--- a/example-queries/workflows-aggregate-query.graphql
+++ b/example-queries/workflows-aggregate-query.graphql
@@ -1,5 +1,5 @@
 query workflowRunsAggregateQuery {
-  workflowRunsAggregate(
+  fedWorkflowRunsAggregate(
     input: {
       where: {
         id: {

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -2,9 +2,9 @@
 import {
   Resolvers,
   query_consensusGenomes_items,
-  query_samples_items,
-  query_sequencingReads_items,
-  query_workflowRunsAggregate_items,
+  query_fedSamples_items,
+  query_fedSequencingReads_items,
+  query_fedWorkflowRunsAggregate_items,
   query_workflowRuns_items,
 } from "./.mesh";
 import { get, postWithCSRF, getFullResponse } from "./utils/httpUtils";
@@ -514,7 +514,7 @@ export const resolvers: Resolvers = {
         return [];
       }
 
-      return workflow_runs.map((run): query_samples_items => {
+      return workflow_runs.map((run): query_fedSamples_items => {
         return {
           id: run.sample?.info?.id?.toString(),
           railsSampleId: run.sample?.info?.id?.toString(),
@@ -564,7 +564,7 @@ export const resolvers: Resolvers = {
         return [];
       }
 
-      const result: query_sequencingReads_items[] = [];
+      const result: query_fedSequencingReads_items[] = [];
 
       for (const run of workflow_runs) {
         const inputs = run.inputs;
@@ -853,7 +853,7 @@ export const resolvers: Resolvers = {
       if (!projects?.length) {
         return [];
       }
-      return projects.map((project): query_workflowRunsAggregate_items => {
+      return projects.map((project): query_fedWorkflowRunsAggregate_items => {
         return {
           collectionId: project.id.toString(),
           mngsRunsCount: project.sample_counts.mngs_runs_count,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -269,7 +269,10 @@ export const resolvers: Resolvers = {
               name: sampleInfo?.name ?? "",
               notes: sampleInfo?.sample_notes,
               uploadError: sampleInfo?.result_status_description,
-              collectionLocation: sampleMetadata?.collection_location_v2 ?? "",
+              collectionLocation:
+                typeof sampleMetadata?.collection_location_v2 === "string"
+                  ? sampleMetadata.collection_location_v2
+                  : sampleMetadata?.collection_location_v2?.name ?? "",
               sampleType: sampleMetadata?.sample_type ?? "",
               waterControl: sampleMetadata?.water_control === "Yes",
               hostOrganism:
@@ -620,7 +623,10 @@ export const resolvers: Resolvers = {
               name: sampleInfo?.name ?? "",
               notes: sampleInfo?.sample_notes,
               uploadError: sampleInfo?.result_status_description,
-              collectionLocation: sampleMetadata?.collection_location_v2 ?? "",
+              collectionLocation:
+                typeof sampleMetadata?.collection_location_v2 === "string"
+                  ? sampleMetadata.collection_location_v2
+                  : sampleMetadata?.collection_location_v2?.name ?? "",
               sampleType: sampleMetadata?.sample_type ?? "",
               waterControl: sampleMetadata?.water_control === "Yes",
               hostOrganism:

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -471,7 +471,7 @@ export const resolvers: Resolvers = {
       return pathogens;
     },
     /** Returns just the sample IDs (and old Rails IDs) to determine which IDs pass the filters. */
-    samples: async (root, args, context) => {
+    fedSamples: async (root, args, context) => {
       const input = args.input;
 
       // The comments in the formatUrlParams() call correspond to the line in the current
@@ -521,7 +521,7 @@ export const resolvers: Resolvers = {
         };
       });
     },
-    sequencingReads: async (root, args, context) => {
+    fedSequencingReads: async (root, args, context) => {
       const input = args.input;
 
       // The comments in the formatUrlParams() call correspond to the line in the current
@@ -824,7 +824,7 @@ export const resolvers: Resolvers = {
         })
       );
     },
-    workflowRunsAggregate: async (root, args, context, info) => {
+    fedWorkflowRunsAggregate: async (root, args, context, info) => {
       const input = args.input;
 
       const { projects } = await get(

--- a/tests/SamplesQuery.test.ts
+++ b/tests/SamplesQuery.test.ts
@@ -31,7 +31,7 @@ describe("samples query:", () => {
       expect.anything(),
       expect.anything()
     );
-    expect(response.data.samples).toHaveLength(0);
+    expect(response.data.fedSamples).toHaveLength(0);
   });
 
   it("Returns IDs", async () => {
@@ -48,7 +48,7 @@ describe("samples query:", () => {
 
     const result = await execute(query, {});
 
-    const samples = result.data.samples;
+    const samples = result.data.fedSamples;
     expect(samples).toHaveLength(2);
     expect(samples[0].id).toEqual("123");
     expect(samples[1].id).toEqual("456");

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -30,7 +30,7 @@ describe("sequencingReads query:", () => {
       expect.anything(),
       expect.anything()
     );
-    expect(response.data.sequencingReads).toHaveLength(0);
+    expect(response.data.fedSequencingReads).toHaveLength(0);
   });
 
   it("Returns nested fields", async () => {
@@ -61,8 +61,8 @@ describe("sequencingReads query:", () => {
 
     const result = await execute(query, {});
 
-    expect(result.data.sequencingReads).toHaveLength(2);
-    expect(result.data.sequencingReads[0]).toEqual(
+    expect(result.data.fedSequencingReads).toHaveLength(2);
+    expect(result.data.fedSequencingReads[0]).toEqual(
       expect.objectContaining({
         id: "123",
         consensusGenomes: {
@@ -78,7 +78,7 @@ describe("sequencingReads query:", () => {
         },
       })
     );
-    expect(result.data.sequencingReads[1]).toEqual(
+    expect(result.data.fedSequencingReads[1]).toEqual(
       expect.objectContaining({
         id: "456",
         consensusGenomes: {
@@ -121,7 +121,7 @@ describe("sequencingReads query:", () => {
     const result = await execute(query, {});
 
     const metadataFields =
-      result.data.sequencingReads[0].sample.metadatas.edges.map(
+      result.data.fedSequencingReads[0].sample.metadatas.edges.map(
         (edge) => edge.node.fieldName
       );
     expect(metadataFields).toHaveLength(3);
@@ -145,9 +145,9 @@ describe("sequencingReads query:", () => {
 
     const result = await execute(query, {});
 
-    expect(result.data.sequencingReads[0].sample.metadatas.edges).toHaveLength(
-      0
-    );
+    expect(
+      result.data.fedSequencingReads[0].sample.metadatas.edges
+    ).toHaveLength(0);
   });
 
   it("Only returns taxon object if name exists", async () => {
@@ -157,7 +157,7 @@ describe("sequencingReads query:", () => {
 
     const result = await execute(query, {});
 
-    expect(result.data.sequencingReads[0].taxon).toBeNull();
+    expect(result.data.fedSequencingReads[0].taxon).toBeNull();
   });
 
   it("Does not return null for required location field", async () => {
@@ -171,7 +171,9 @@ describe("sequencingReads query:", () => {
 
     const result = await execute(query, {});
 
-    expect(result.data.sequencingReads[0].sample.collectionLocation).toBe("");
+    expect(result.data.fedSequencingReads[0].sample.collectionLocation).toBe(
+      ""
+    );
   });
 
   it("Returns string location field", async () => {
@@ -189,7 +191,7 @@ describe("sequencingReads query:", () => {
 
     const result = await execute(query, {});
 
-    expect(result.data.sequencingReads[0].sample.collectionLocation).toBe(
+    expect(result.data.fedSequencingReads[0].sample.collectionLocation).toBe(
       "Redwood City"
     );
   });
@@ -211,7 +213,7 @@ describe("sequencingReads query:", () => {
 
     const result = await execute(query, {});
 
-    expect(result.data.sequencingReads[0].sample.collectionLocation).toBe(
+    expect(result.data.fedSequencingReads[0].sample.collectionLocation).toBe(
       "Redwood City"
     );
   });
@@ -231,7 +233,7 @@ describe("sequencingReads query:", () => {
 
     const result = await execute(query, {});
 
-    expect(result.data.sequencingReads[0].sample.waterControl).toBe(true);
+    expect(result.data.fedSequencingReads[0].sample.waterControl).toBe(true);
   });
 
   it("Returns unique sequencing reads", async () => {
@@ -284,7 +286,7 @@ describe("sequencingReads query:", () => {
       ],
     }));
 
-    const sequencingReads = (await execute(query, {})).data.sequencingReads;
+    const sequencingReads = (await execute(query, {})).data.fedSequencingReads;
 
     expect(sequencingReads.length).toBe(2);
 

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -174,6 +174,48 @@ describe("sequencingReads query:", () => {
     expect(result.data.sequencingReads[0].sample.collectionLocation).toBe("");
   });
 
+  it("Returns string location field", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {
+            metadata: {
+              collection_location_v2: "Redwood City",
+            },
+          },
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    expect(result.data.sequencingReads[0].sample.collectionLocation).toBe(
+      "Redwood City"
+    );
+  });
+
+  it("Returns object name for location field", async () => {
+    (httpUtils.get as jest.Mock).mockImplementation(() => ({
+      workflow_runs: [
+        {
+          sample: {
+            metadata: {
+              collection_location_v2: {
+                name: "Redwood City",
+              },
+            },
+          },
+        },
+      ],
+    }));
+
+    const result = await execute(query, {});
+
+    expect(result.data.sequencingReads[0].sample.collectionLocation).toBe(
+      "Redwood City"
+    );
+  });
+
   it("Converts water control to boolean", async () => {
     (httpUtils.get as jest.Mock).mockImplementation(() => ({
       workflow_runs: [

--- a/tests/WorkflowRunsAggregateQuery.test.ts
+++ b/tests/WorkflowRunsAggregateQuery.test.ts
@@ -25,9 +25,9 @@ describe("workflows aggregate query:", () => {
           sample_counts: {
             cg_runs_count: 1,
             amr_runs_count: 2,
-            mngs_runs_count: 3
-          }
-        }
+            mngs_runs_count: 3,
+          },
+        },
       ],
     }));
 
@@ -40,10 +40,10 @@ describe("workflows aggregate query:", () => {
       expect.anything()
     );
 
-    expect(response.data.workflowRunsAggregate).toHaveLength(1);
-    expect(response.data.workflowRunsAggregate[0].collectionId).toBe("1");
-    expect(response.data.workflowRunsAggregate[0].amrRunsCount).toBe(2);
-    expect(response.data.workflowRunsAggregate[0].cgRunsCount).toBe(1);
-    expect(response.data.workflowRunsAggregate[0].mngsRunsCount).toBe(3);
+    expect(response.data.fedWorkflowRunsAggregate).toHaveLength(1);
+    expect(response.data.fedWorkflowRunsAggregate[0].collectionId).toBe("1");
+    expect(response.data.fedWorkflowRunsAggregate[0].amrRunsCount).toBe(2);
+    expect(response.data.fedWorkflowRunsAggregate[0].cgRunsCount).toBe(1);
+    expect(response.data.fedWorkflowRunsAggregate[0].mngsRunsCount).toBe(3);
   });
 });

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -26,7 +26,7 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
     ids: [GlobalID!]!
   ): [Node!]!
   files(where: FileWhereClause = null): [File!]!
-  samples(input: queryInput_samples_input_Input): [query_samples_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
+  samples(where: SampleWhereClause = null): [Sample!]!
   genomicRanges(where: GenomicRangeWhereClause = null): [GenomicRange!]!
   referenceGenomes(where: ReferenceGenomeWhereClause = null): [ReferenceGenome!]!
   sequenceAlignmentIndices(where: SequenceAlignmentIndexWhereClause = null): [SequenceAlignmentIndex!]!
@@ -69,13 +69,14 @@ type Query @globalOptions(sourceName: "CZIDREST", endpoint: "http://web:3001/") 
   Pathogens(snapshotLinkId: String, sampleId: String, workflowVersionId: String): [query_Pathogens_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   PersistedBackground(projectId: String): PersistedBackground @httpOperation(path: "/persisted_backgrounds/{args.projectId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   PipelineData(sampleId: String, workflowVersionId: String): PipelineData @httpOperation(path: "/samples/{args.sampleId}/pipeline_viz/{args.workflowVersionId}.json", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
-  sequencingReads(input: queryInput_sequencingReads_input_Input): [query_sequencingReads_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
+  fedSamples(input: queryInput_fedSamples_input_Input): [query_fedSamples_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
+  fedSequencingReads(input: queryInput_fedSequencingReads_input_Input): [query_fedSequencingReads_items] @httpOperation(path: "/workflow_runs.json", httpMethod: GET)
   Taxons(snapshotLinkId: String, sampleId: String, workflowVersionId: String): [query_Taxons_items] @httpOperation(path: "/pub/{args.snapshotLinkId}/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   TaxonDist(backgroundId: String, taxonId: String): TaxonDist @httpOperation(path: "/backgrounds/{args.backgroundId}/show_taxon_dist.json?taxid={args.taxonId}", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: GET)
   UserBlastAnnotations(sampleId: String, workflowVersionId: String): [query_UserBlastAnnotations_items] @httpOperation(path: "/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   ValidateUserCanDeleteObjects(input: queryInput_ValidateUserCanDeleteObjects_input_Input): ValidateUserCanDeleteObjects @httpOperation(path: "/samples/validate_user_can_delete_objects.json", httpMethod: POST)
   workflowRuns(input: queryInput_workflowRuns_input_Input): [query_workflowRuns_items] @httpOperation(path: "/workflow_runs.json", httpMethod: POST)
-  workflowRunsAggregate(input: queryInput_workflowRunsAggregate_input_Input): [query_workflowRunsAggregate_items] @httpOperation(path: "/projects.json", httpMethod: GET)
+  fedWorkflowRunsAggregate(input: queryInput_fedWorkflowRunsAggregate_input_Input): [query_fedWorkflowRunsAggregate_items] @httpOperation(path: "/projects.json", httpMethod: GET)
   ZipLink(workflowRunId: String): ZipLink @httpOperation(path: "/workflow_runs/{args.workflowRunId}/zip_link.json", httpMethod: GET)
   GraphQLFederationVersion: GraphQLFederationVersion
 }
@@ -2862,111 +2863,111 @@ type query_PipelineData_edges_items_files_items {
   url: JSON
 }
 
-type query_samples_items {
+type query_fedSamples_items {
   id: String!
   railsSampleId: Int
 }
 
-input queryInput_samples_input_Input {
-  where: queryInput_samples_input_where_Input
-  orderBy: queryInput_samples_input_orderBy_Input
-  sequencingReadsInput: queryInput_samples_input_sequencingReadsInput_Input
-  todoRemove: queryInput_samples_input_todoRemove_Input
+input queryInput_fedSamples_input_Input {
+  where: queryInput_fedSamples_input_where_Input
+  orderBy: queryInput_fedSamples_input_orderBy_Input
+  sequencingReadsInput: queryInput_fedSamples_input_sequencingReadsInput_Input
+  todoRemove: queryInput_fedSamples_input_todoRemove_Input
 }
 
-input queryInput_samples_input_where_Input {
-  id: queryInput_samples_input_where_id_Input
-  name: queryInput_samples_input_where_name_Input
-  collectionLocation: queryInput_samples_input_where_collectionLocation_Input
-  sampleType: queryInput_samples_input_where_sampleType_Input
-  hostOrganism: queryInput_samples_input_where_hostOrganism_Input
-  sequencingReads: queryInput_samples_input_where_sequencingReads_Input
+input queryInput_fedSamples_input_where_Input {
+  id: queryInput_fedSamples_input_where_id_Input
+  name: queryInput_fedSamples_input_where_name_Input
+  collectionLocation: queryInput_fedSamples_input_where_collectionLocation_Input
+  sampleType: queryInput_fedSamples_input_where_sampleType_Input
+  hostOrganism: queryInput_fedSamples_input_where_hostOrganism_Input
+  sequencingReads: queryInput_fedSamples_input_where_sequencingReads_Input
 }
 
-input queryInput_samples_input_where_id_Input {
+input queryInput_fedSamples_input_where_id_Input {
   _in: [String]
 }
 
-input queryInput_samples_input_where_name_Input {
+input queryInput_fedSamples_input_where_name_Input {
   _like: String
 }
 
-input queryInput_samples_input_where_collectionLocation_Input {
+input queryInput_fedSamples_input_where_collectionLocation_Input {
   _in: [String]
 }
 
-input queryInput_samples_input_where_sampleType_Input {
+input queryInput_fedSamples_input_where_sampleType_Input {
   _in: [String]
 }
 
-input queryInput_samples_input_where_hostOrganism_Input {
-  name: queryInput_samples_input_where_hostOrganism_name_Input
+input queryInput_fedSamples_input_where_hostOrganism_Input {
+  name: queryInput_fedSamples_input_where_hostOrganism_name_Input
 }
 
-input queryInput_samples_input_where_hostOrganism_name_Input {
+input queryInput_fedSamples_input_where_hostOrganism_name_Input {
   _in: [String]
 }
 
-input queryInput_samples_input_where_sequencingReads_Input {
-  taxon: queryInput_samples_input_where_sequencingReads_taxon_Input
-  consensusGenomes: queryInput_samples_input_where_sequencingReads_consensusGenomes_Input
+input queryInput_fedSamples_input_where_sequencingReads_Input {
+  taxon: queryInput_fedSamples_input_where_sequencingReads_taxon_Input
+  consensusGenomes: queryInput_fedSamples_input_where_sequencingReads_consensusGenomes_Input
 }
 
-input queryInput_samples_input_where_sequencingReads_taxon_Input {
-  name: queryInput_samples_input_where_sequencingReads_taxon_name_Input
+input queryInput_fedSamples_input_where_sequencingReads_taxon_Input {
+  name: queryInput_fedSamples_input_where_sequencingReads_taxon_name_Input
 }
 
-input queryInput_samples_input_where_sequencingReads_taxon_name_Input {
+input queryInput_fedSamples_input_where_sequencingReads_taxon_name_Input {
   _in: [String]
 }
 
-input queryInput_samples_input_where_sequencingReads_consensusGenomes_Input {
-  taxon: queryInput_samples_input_where_sequencingReads_consensusGenomes_taxon_Input
+input queryInput_fedSamples_input_where_sequencingReads_consensusGenomes_Input {
+  taxon: queryInput_fedSamples_input_where_sequencingReads_consensusGenomes_taxon_Input
 }
 
-input queryInput_samples_input_where_sequencingReads_consensusGenomes_taxon_Input {
-  name: queryInput_samples_input_where_sequencingReads_consensusGenomes_taxon_name_Input
+input queryInput_fedSamples_input_where_sequencingReads_consensusGenomes_taxon_Input {
+  name: queryInput_fedSamples_input_where_sequencingReads_consensusGenomes_taxon_name_Input
 }
 
-input queryInput_samples_input_where_sequencingReads_consensusGenomes_taxon_name_Input {
+input queryInput_fedSamples_input_where_sequencingReads_consensusGenomes_taxon_name_Input {
   _in: [String]
 }
 
-input queryInput_samples_input_orderBy_Input {
+input queryInput_fedSamples_input_orderBy_Input {
   key: String
   dir: String
 }
 
-input queryInput_samples_input_sequencingReadsInput_Input {
-  where: queryInput_samples_input_sequencingReadsInput_where_Input
+input queryInput_fedSamples_input_sequencingReadsInput_Input {
+  where: queryInput_fedSamples_input_sequencingReadsInput_where_Input
 }
 
-input queryInput_samples_input_sequencingReadsInput_where_Input {
-  taxon: queryInput_samples_input_sequencingReadsInput_where_taxon_Input
-  consensusGenomes: queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_Input
+input queryInput_fedSamples_input_sequencingReadsInput_where_Input {
+  taxon: queryInput_fedSamples_input_sequencingReadsInput_where_taxon_Input
+  consensusGenomes: queryInput_fedSamples_input_sequencingReadsInput_where_consensusGenomes_Input
 }
 
-input queryInput_samples_input_sequencingReadsInput_where_taxon_Input {
-  name: queryInput_samples_input_sequencingReadsInput_where_taxon_name_Input
+input queryInput_fedSamples_input_sequencingReadsInput_where_taxon_Input {
+  name: queryInput_fedSamples_input_sequencingReadsInput_where_taxon_name_Input
 }
 
-input queryInput_samples_input_sequencingReadsInput_where_taxon_name_Input {
+input queryInput_fedSamples_input_sequencingReadsInput_where_taxon_name_Input {
   _in: [String]
 }
 
-input queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_Input {
-  taxon: queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_taxon_Input
+input queryInput_fedSamples_input_sequencingReadsInput_where_consensusGenomes_Input {
+  taxon: queryInput_fedSamples_input_sequencingReadsInput_where_consensusGenomes_taxon_Input
 }
 
-input queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_taxon_Input {
-  name: queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_taxon_name_Input
+input queryInput_fedSamples_input_sequencingReadsInput_where_consensusGenomes_taxon_Input {
+  name: queryInput_fedSamples_input_sequencingReadsInput_where_consensusGenomes_taxon_name_Input
 }
 
-input queryInput_samples_input_sequencingReadsInput_where_consensusGenomes_taxon_name_Input {
+input queryInput_fedSamples_input_sequencingReadsInput_where_consensusGenomes_taxon_name_Input {
   _in: [String]
 }
 
-input queryInput_samples_input_todoRemove_Input {
+input queryInput_fedSamples_input_todoRemove_Input {
   domain: String
   visibility: String
   time: [String]
@@ -2979,22 +2980,22 @@ input queryInput_samples_input_todoRemove_Input {
   listAllIds: Boolean
 }
 
-type query_sequencingReads_items {
+type query_fedSequencingReads_items {
   id: String!
   nucleicAcid: String!
   protocol: String
   medakaModel: String
   technology: String!
-  taxon: query_sequencingReads_items_taxon
-  sample: query_sequencingReads_items_sample
-  consensusGenomes: query_sequencingReads_items_consensusGenomes!
+  taxon: query_fedSequencingReads_items_taxon
+  sample: query_fedSequencingReads_items_sample
+  consensusGenomes: query_fedSequencingReads_items_consensusGenomes!
 }
 
-type query_sequencingReads_items_taxon {
+type query_fedSequencingReads_items_taxon {
   name: String!
 }
 
-type query_sequencingReads_items_sample {
+type query_fedSequencingReads_items_sample {
   railsSampleId: Int
   name: String!
   notes: String
@@ -3002,60 +3003,60 @@ type query_sequencingReads_items_sample {
   sampleType: String!
   waterControl: Boolean
   uploadError: String
-  hostOrganism: query_sequencingReads_items_sample_hostOrganism
-  collection: query_sequencingReads_items_sample_collection
+  hostOrganism: query_fedSequencingReads_items_sample_hostOrganism
+  collection: query_fedSequencingReads_items_sample_collection
   ownerUserId: Float
   ownerUserName: String
-  metadatas: query_sequencingReads_items_sample_metadatas!
+  metadatas: query_fedSequencingReads_items_sample_metadatas!
 }
 
-type query_sequencingReads_items_sample_hostOrganism {
+type query_fedSequencingReads_items_sample_hostOrganism {
   name: String!
 }
 
-type query_sequencingReads_items_sample_collection {
+type query_fedSequencingReads_items_sample_collection {
   name: String
   public: Boolean
 }
 
-type query_sequencingReads_items_sample_metadatas {
-  edges: [query_sequencingReads_items_sample_metadatas_edges_items]!
+type query_fedSequencingReads_items_sample_metadatas {
+  edges: [query_fedSequencingReads_items_sample_metadatas_edges_items]!
 }
 
-type query_sequencingReads_items_sample_metadatas_edges_items {
-  node: query_sequencingReads_items_sample_metadatas_edges_items_node!
+type query_fedSequencingReads_items_sample_metadatas_edges_items {
+  node: query_fedSequencingReads_items_sample_metadatas_edges_items_node!
 }
 
-type query_sequencingReads_items_sample_metadatas_edges_items_node {
+type query_fedSequencingReads_items_sample_metadatas_edges_items_node {
   fieldName: String!
   value: String!
 }
 
-type query_sequencingReads_items_consensusGenomes {
-  edges: [query_sequencingReads_items_consensusGenomes_edges_items]!
+type query_fedSequencingReads_items_consensusGenomes {
+  edges: [query_fedSequencingReads_items_consensusGenomes_edges_items]!
 }
 
-type query_sequencingReads_items_consensusGenomes_edges_items {
-  node: query_sequencingReads_items_consensusGenomes_edges_items_node!
+type query_fedSequencingReads_items_consensusGenomes_edges_items {
+  node: query_fedSequencingReads_items_consensusGenomes_edges_items_node!
 }
 
-type query_sequencingReads_items_consensusGenomes_edges_items_node {
+type query_fedSequencingReads_items_consensusGenomes_edges_items_node {
   producingRunId: String
-  taxon: query_sequencingReads_items_consensusGenomes_edges_items_node_taxon
-  referenceGenome: query_sequencingReads_items_consensusGenomes_edges_items_node_referenceGenome
-  metrics: query_sequencingReads_items_consensusGenomes_edges_items_node_metrics
+  taxon: query_fedSequencingReads_items_consensusGenomes_edges_items_node_taxon
+  referenceGenome: query_fedSequencingReads_items_consensusGenomes_edges_items_node_referenceGenome
+  metrics: query_fedSequencingReads_items_consensusGenomes_edges_items_node_metrics
 }
 
-type query_sequencingReads_items_consensusGenomes_edges_items_node_taxon {
+type query_fedSequencingReads_items_consensusGenomes_edges_items_node_taxon {
   name: String!
 }
 
-type query_sequencingReads_items_consensusGenomes_edges_items_node_referenceGenome {
+type query_fedSequencingReads_items_consensusGenomes_edges_items_node_referenceGenome {
   accessionId: String
   accessionName: String
 }
 
-type query_sequencingReads_items_consensusGenomes_edges_items_node_metrics {
+type query_fedSequencingReads_items_consensusGenomes_edges_items_node_metrics {
   coverageDepth: Float
   totalReads: Int
   gcPercent: Float
@@ -3068,63 +3069,63 @@ type query_sequencingReads_items_consensusGenomes_edges_items_node_metrics {
   referenceGenomeLength: Float
 }
 
-input queryInput_sequencingReads_input_Input {
+input queryInput_fedSequencingReads_input_Input {
   limit: Int
   offset: Int
-  where: queryInput_sequencingReads_input_where_Input
-  orderBy: queryInput_sequencingReads_input_orderBy_Input
-  consensusGenomesInput: queryInput_sequencingReads_input_consensusGenomesInput_Input
-  todoRemove: queryInput_sequencingReads_input_todoRemove_Input
+  where: queryInput_fedSequencingReads_input_where_Input
+  orderBy: queryInput_fedSequencingReads_input_orderBy_Input
+  consensusGenomesInput: queryInput_fedSequencingReads_input_consensusGenomesInput_Input
+  todoRemove: queryInput_fedSequencingReads_input_todoRemove_Input
 }
 
-input queryInput_sequencingReads_input_where_Input {
-  id: queryInput_sequencingReads_input_where_id_Input
+input queryInput_fedSequencingReads_input_where_Input {
+  id: queryInput_fedSequencingReads_input_where_id_Input
 }
 
-input queryInput_sequencingReads_input_where_id_Input {
+input queryInput_fedSequencingReads_input_where_id_Input {
   _in: [String]
 }
 
-input queryInput_sequencingReads_input_orderBy_Input {
+input queryInput_fedSequencingReads_input_orderBy_Input {
   protocol: String
   technology: String
   medakaModel: String
   nucleicAcid: String
-  sample: queryInput_sequencingReads_input_orderBy_sample_Input
+  sample: queryInput_fedSequencingReads_input_orderBy_sample_Input
 }
 
-input queryInput_sequencingReads_input_orderBy_sample_Input {
+input queryInput_fedSequencingReads_input_orderBy_sample_Input {
   name: String
   notes: String
   sampleType: String
   waterControl: String
   collectionLocation: String
-  hostOrganism: queryInput_sequencingReads_input_orderBy_sample_hostOrganism_Input
-  metadata: queryInput_sequencingReads_input_orderBy_sample_metadata_Input
+  hostOrganism: queryInput_fedSequencingReads_input_orderBy_sample_hostOrganism_Input
+  metadata: queryInput_fedSequencingReads_input_orderBy_sample_metadata_Input
 }
 
-input queryInput_sequencingReads_input_orderBy_sample_hostOrganism_Input {
+input queryInput_fedSequencingReads_input_orderBy_sample_hostOrganism_Input {
   name: String
 }
 
-input queryInput_sequencingReads_input_orderBy_sample_metadata_Input {
+input queryInput_fedSequencingReads_input_orderBy_sample_metadata_Input {
   fieldName: String
   dir: String
 }
 
-input queryInput_sequencingReads_input_consensusGenomesInput_Input {
-  where: queryInput_sequencingReads_input_consensusGenomesInput_where_Input
+input queryInput_fedSequencingReads_input_consensusGenomesInput_Input {
+  where: queryInput_fedSequencingReads_input_consensusGenomesInput_where_Input
 }
 
-input queryInput_sequencingReads_input_consensusGenomesInput_where_Input {
-  producingRunId: queryInput_sequencingReads_input_consensusGenomesInput_where_producingRunId_Input
+input queryInput_fedSequencingReads_input_consensusGenomesInput_where_Input {
+  producingRunId: queryInput_fedSequencingReads_input_consensusGenomesInput_where_producingRunId_Input
 }
 
-input queryInput_sequencingReads_input_consensusGenomesInput_where_producingRunId_Input {
+input queryInput_fedSequencingReads_input_consensusGenomesInput_where_producingRunId_Input {
   _in: [String]
 }
 
-input queryInput_sequencingReads_input_todoRemove_Input {
+input queryInput_fedSequencingReads_input_todoRemove_Input {
   domain: String
   workflow: String
   projectId: String
@@ -3315,33 +3316,33 @@ input queryInput_workflowRuns_input_entityInputsInput_where_fieldName_Input {
   _eq: String
 }
 
-type query_workflowRunsAggregate_items {
+type query_fedWorkflowRunsAggregate_items {
   collectionId: String!
   mngsRunsCount: Int!
   cgRunsCount: Int!
   amrRunsCount: Int!
 }
 
-input queryInput_workflowRunsAggregate_input_Input {
-  where: queryInput_workflowRunsAggregate_input_where_Input
-  todoRemove: queryInput_workflowRunsAggregate_input_todoRemove_Input
+input queryInput_fedWorkflowRunsAggregate_input_Input {
+  where: queryInput_fedWorkflowRunsAggregate_input_where_Input
+  todoRemove: queryInput_fedWorkflowRunsAggregate_input_todoRemove_Input
 }
 
-input queryInput_workflowRunsAggregate_input_where_Input {
-  id: queryInput_workflowRunsAggregate_input_where_id_Input
+input queryInput_fedWorkflowRunsAggregate_input_where_Input {
+  id: queryInput_fedWorkflowRunsAggregate_input_where_id_Input
 }
 
-input queryInput_workflowRunsAggregate_input_where_id_Input {
+input queryInput_fedWorkflowRunsAggregate_input_where_id_Input {
   _in: [String]
 }
 
-input queryInput_workflowRunsAggregate_input_todoRemove_Input {
+input queryInput_fedWorkflowRunsAggregate_input_todoRemove_Input {
   projectId: String
   domain: String
   host: [Int]
   locationV2: [String]
-  taxonThresholds: [queryInput_workflowRunsAggregate_input_todoRemove_taxonThresholds_items_Input]
-  annotations: [queryInput_workflowRunsAggregate_input_todoRemove_annotations_items_Input]
+  taxonThresholds: [queryInput_fedWorkflowRunsAggregate_input_todoRemove_taxonThresholds_items_Input]
+  annotations: [queryInput_fedWorkflowRunsAggregate_input_todoRemove_annotations_items_Input]
   tissue: [String]
   visibility: String
   time: [String]
@@ -3350,14 +3351,14 @@ input queryInput_workflowRunsAggregate_input_todoRemove_Input {
   search: String
 }
 
-input queryInput_workflowRunsAggregate_input_todoRemove_taxonThresholds_items_Input {
+input queryInput_fedWorkflowRunsAggregate_input_todoRemove_taxonThresholds_items_Input {
   metric: String
   count_type: String
   operator: String
   value: String
 }
 
-input queryInput_workflowRunsAggregate_input_todoRemove_annotations_items_Input {
+input queryInput_fedWorkflowRunsAggregate_input_todoRemove_annotations_items_Input {
   name: String
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Adds `fed` prefix to:

- `samples`
- `sequencingReads`
- `workflowRunsAggregate`

None of these are used in prod right now.

Suzette is taking care of `consensusGenomes`. `workflowRuns` is in prod but does not conflict in response type, so hopefully it will just work once the NextGen schema and types are available on the FE.

This also adds a small fix to the `location` field (that seems to be the only metadata field that can either be an `object` or a `string`...).
