### PR TITLE
chore: Duplicate the JSON schema files for workflowRuns so that it generates different input types

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -192,12 +192,14 @@ sources:
             method: POST
             requestSchema: ./json-schemas/workflowRunsRequest.json
             responseSchema: ./json-schemas/workflowRunsResponse.json
+            responseTypeName: workflowRuns
           - type: Query
             field: fedWorkflowRuns
             path: /workflow_runs.json
             method: POST
-            requestSchema: ./json-schemas/workflowRunsRequest.json
-            responseSchema: ./json-schemas/workflowRunsResponse.json
+            requestSchema: ./json-schemas/fedWorkflowRunsRequest.json
+            responseSchema: ./json-schemas/fedWorkflowRunsResponse.json
+            responseTypeName: fedWorkflowRuns
           - type: Query
             field: fedWorkflowRunsAggregate
             path: /projects.json

--- a/json-schemas/fedWorkflowRunsRequest.json
+++ b/json-schemas/fedWorkflowRunsRequest.json
@@ -1,0 +1,176 @@
+{
+    "type": "object",
+    "properties": {
+        "todoRemove": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string"
+                },
+                "projectId": {
+                    "type": "string"
+                },
+                "search": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "locationV2": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "taxon": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "taxonLevels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "time": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tissue": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "visibility": {
+                    "type": "string"
+                },
+                "workflow": {
+                    "type": "string"
+                },
+                "orderBy": {
+                    "type": "string"
+                },
+                "orderDir": {
+                    "type": "string"
+                },
+                "authenticityToken": {
+                    "type": "string"
+                }
+            }
+        },
+        "orderBy": {
+            "type": "object",
+            "properties": {
+                "startedAt": {
+                    "type": "string"
+                },
+                "workflowVersion": {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "type": "string"
+                        },
+                        "workflow": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "where": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "object",
+                    "properties": {
+                        "_in": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "ownerUserId": {
+                    "type": "object",
+                    "properties": {
+                        "_eq": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "startedAt": {
+                    "type": "object",
+                    "properties": {
+                        "_gte": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "collectionId": {
+                    "type": "object",
+                    "properties": {
+                        "_in": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
+                "workflowVersion": {
+                    "type": "object",
+                    "properties": {
+                        "workflow": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "entityInputsInput": {
+            "type": "object",
+            "properties": {
+                "where": {
+                    "type": "object",
+                    "properties": {
+                        "fieldName": {
+                            "type": "object",
+                            "properties": {
+                                "_eq": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/json-schemas/fedWorkflowRunsResponse.json
+++ b/json-schemas/fedWorkflowRunsResponse.json
@@ -1,0 +1,63 @@
+{
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "ownerUserId": {
+                "type": "integer"
+            },
+            "startedAt": {
+                "type": "string"
+            },
+            "status": {
+                "type": "string"
+            },
+            "workflowVersion": {
+                "type": "object",
+                "properties": {
+                    "version": {
+                        "type": "string"
+                    },
+                    "workflow": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "entityInputs": {
+                "type": "object",
+                "properties": {
+                    "edges": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "node": {
+                                    "type": "object",
+                                    "properties": {
+                                        "inputEntityId": {
+                                            "type": "string"
+                                        },
+                                        "entityType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "required": ["node"]
+                        }
+                    }
+                },
+                "required": ["edges"]
+            }
+        },
+        "required": ["id", "ownerUserId", "entityInputs"]
+    }
+}

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -90,7 +90,7 @@ type Query {
   UserBlastAnnotations(sampleId: String, workflowVersionId: String): [query_UserBlastAnnotations_items] @httpOperation(subgraph: "CZIDREST", path: "/samples/{args.sampleId}/report_v2?&id={args.sampleId}&pipeline_version={args.workflowVersionId}&merge_nt_nr=false", httpMethod: GET)
   ValidateUserCanDeleteObjects(input: queryInput_ValidateUserCanDeleteObjects_input_Input): ValidateUserCanDeleteObjects @httpOperation(subgraph: "CZIDREST", path: "/samples/validate_user_can_delete_objects.json", httpMethod: POST)
   workflowRuns(input: queryInput_workflowRuns_input_Input): [query_workflowRuns_items] @httpOperation(subgraph: "CZIDREST", path: "/workflow_runs.json", httpMethod: POST)
-  fedWorkflowRuns(input: queryInput_workflowRuns_input_Input): [query_workflowRuns_items] @httpOperation(subgraph: "CZIDREST", path: "/workflow_runs.json", httpMethod: POST)
+  fedWorkflowRuns(input: queryInput_fedWorkflowRuns_input_Input): [query_fedWorkflowRuns_items] @httpOperation(subgraph: "CZIDREST", path: "/workflow_runs.json", httpMethod: POST)
   fedWorkflowRunsAggregate(input: queryInput_fedWorkflowRunsAggregate_input_Input): [query_fedWorkflowRunsAggregate_items] @httpOperation(subgraph: "CZIDREST", path: "/projects.json", httpMethod: GET)
   ZipLink(workflowRunId: String): ZipLink @httpOperation(subgraph: "CZIDREST", path: "/workflow_runs/{args.workflowRunId}/zip_link.json", httpMethod: GET)
   GraphQLFederationVersion: GraphQLFederationVersion
@@ -4526,6 +4526,123 @@ input queryInput_workflowRuns_input_entityInputsInput_where_Input {
 }
 
 input queryInput_workflowRuns_input_entityInputsInput_where_fieldName_Input {
+  _eq: String
+}
+
+type query_fedWorkflowRuns_items {
+  id: String!
+  ownerUserId: Int!
+  startedAt: String
+  status: String
+  workflowVersion: query_fedWorkflowRuns_items_workflowVersion
+  entityInputs: query_fedWorkflowRuns_items_entityInputs!
+}
+
+type query_fedWorkflowRuns_items_workflowVersion {
+  version: String
+  workflow: query_fedWorkflowRuns_items_workflowVersion_workflow
+}
+
+type query_fedWorkflowRuns_items_workflowVersion_workflow {
+  name: String
+}
+
+type query_fedWorkflowRuns_items_entityInputs {
+  edges: [query_fedWorkflowRuns_items_entityInputs_edges_items]!
+}
+
+type query_fedWorkflowRuns_items_entityInputs_edges_items {
+  node: query_fedWorkflowRuns_items_entityInputs_edges_items_node!
+}
+
+type query_fedWorkflowRuns_items_entityInputs_edges_items_node {
+  inputEntityId: String
+  entityType: String
+}
+
+input queryInput_fedWorkflowRuns_input_Input {
+  todoRemove: queryInput_fedWorkflowRuns_input_todoRemove_Input
+  orderBy: queryInput_fedWorkflowRuns_input_orderBy_Input
+  where: queryInput_fedWorkflowRuns_input_where_Input
+  entityInputsInput: queryInput_fedWorkflowRuns_input_entityInputsInput_Input
+}
+
+input queryInput_fedWorkflowRuns_input_todoRemove_Input {
+  domain: String
+  projectId: String
+  search: String
+  host: [Int]
+  locationV2: [String]
+  taxon: [Int]
+  taxonLevels: [String]
+  time: [String]
+  tissue: [String]
+  visibility: String
+  workflow: String
+  orderBy: String
+  orderDir: String
+  authenticityToken: String
+}
+
+input queryInput_fedWorkflowRuns_input_orderBy_Input {
+  startedAt: String
+  workflowVersion: queryInput_fedWorkflowRuns_input_orderBy_workflowVersion_Input
+}
+
+input queryInput_fedWorkflowRuns_input_orderBy_workflowVersion_Input {
+  version: String
+  workflow: queryInput_fedWorkflowRuns_input_orderBy_workflowVersion_workflow_Input
+}
+
+input queryInput_fedWorkflowRuns_input_orderBy_workflowVersion_workflow_Input {
+  name: String
+}
+
+input queryInput_fedWorkflowRuns_input_where_Input {
+  id: queryInput_fedWorkflowRuns_input_where_id_Input
+  ownerUserId: queryInput_fedWorkflowRuns_input_where_ownerUserId_Input
+  startedAt: queryInput_fedWorkflowRuns_input_where_startedAt_Input
+  collectionId: queryInput_fedWorkflowRuns_input_where_collectionId_Input
+  workflowVersion: queryInput_fedWorkflowRuns_input_where_workflowVersion_Input
+}
+
+input queryInput_fedWorkflowRuns_input_where_id_Input {
+  _in: [String]
+}
+
+input queryInput_fedWorkflowRuns_input_where_ownerUserId_Input {
+  _eq: Int
+}
+
+input queryInput_fedWorkflowRuns_input_where_startedAt_Input {
+  _gte: String
+}
+
+input queryInput_fedWorkflowRuns_input_where_collectionId_Input {
+  _in: [Int]
+}
+
+input queryInput_fedWorkflowRuns_input_where_workflowVersion_Input {
+  workflow: queryInput_fedWorkflowRuns_input_where_workflowVersion_workflow_Input
+}
+
+input queryInput_fedWorkflowRuns_input_where_workflowVersion_workflow_Input {
+  name: queryInput_fedWorkflowRuns_input_where_workflowVersion_workflow_name_Input
+}
+
+input queryInput_fedWorkflowRuns_input_where_workflowVersion_workflow_name_Input {
+  _in: [String]
+}
+
+input queryInput_fedWorkflowRuns_input_entityInputsInput_Input {
+  where: queryInput_fedWorkflowRuns_input_entityInputsInput_where_Input
+}
+
+input queryInput_fedWorkflowRuns_input_entityInputsInput_where_Input {
+  fieldName: queryInput_fedWorkflowRuns_input_entityInputsInput_where_fieldName_Input
+}
+
+input queryInput_fedWorkflowRuns_input_entityInputsInput_where_fieldName_Input {
   _eq: String
 }
 


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

If I reuse the schema files, Mesh will generate the same input and response type names for the 2 queries, which might cause the requests to break during the transition where we delete the old federated `workflowRuns` field (which would cause the type to switch from `workflowRunsInput` to `fedWorkflowRunsInput`).

## Tests

Unused endpoint.
