### PR TITLE
fix: createBulkDownload Change workflowRunIdsStrings type and remove required for workflowRunIds

### DIFF
--- a/json-schemas/createBulkDownloadCSV.json
+++ b/json-schemas/createBulkDownloadCSV.json
@@ -13,7 +13,7 @@
         "workflowRunIdsStrings": {
             "type": "array",
             "items": {
-                "type": "strings"
+                "type": "string"
             }
         },
         "workflow": {
@@ -26,5 +26,5 @@
             "type": "string"
         }
     },
-    "required": ["downloadType", "workflowRunIds", "workflow", "includeMetadata", "authenticityToken"]
+    "required": ["downloadType", "workflow", "includeMetadata", "authenticityToken"]
 }

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -3697,8 +3697,8 @@ input queryInput_BulkDownloadCGOverview_input_Input {
   downloadType: String!
   includeMetadata: Boolean!
   workflow: String!
-  workflowRunIds: [Int]!
-  workflowRunIdsStrings: [JSON]
+  workflowRunIds: [Int]
+  workflowRunIdsStrings: [String]
 }
 
 input queryInput_MetadataFields_input_Input {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket
none

## Description
Change workflowRunIdsStrings type and remove required for workflowRunIds so the frontend can choose to send only workflowRunIdsStrings.

## Notes

*Optional observations, comments or explanations.*
*If implementing a new feature, note any relevant analytics added.*

## Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*
