### PR TITLE
fix: Change to underscore entity input format

### DIFF
--- a/resolvers.ts
+++ b/resolvers.ts
@@ -981,7 +981,7 @@ export const resolvers: Resolvers = {
             edges: [
               {
                 node: {
-                  entityType: "SequencingRead",
+                  entityType: "sequencing_read",
                   inputEntityId: run.sample?.info?.id?.toString(),
                 },
               },

--- a/tests/WorkflowRunsQuery.test.ts
+++ b/tests/WorkflowRunsQuery.test.ts
@@ -66,7 +66,7 @@ describe("workflowRuns query:", () => {
           edges: [
             {
               node: {
-                entityType: "SequencingRead",
+                entityType: "sequencing_read",
                 inputEntityId: "2",
               },
             },
@@ -81,7 +81,7 @@ describe("workflowRuns query:", () => {
           edges: [
             {
               node: {
-                entityType: "SequencingRead",
+                entityType: "sequencing_read",
                 inputEntityId: "4",
               },
             },
@@ -154,7 +154,7 @@ describe("workflowRuns query:", () => {
               name
             }
           }
-          entityInputs(where: { entityType: { _eq: "SequencingRead" } }) {
+          entityInputs(where: { entityType: { _eq: "sequencing_read" } }) {
             edges {
               node {
                 inputEntityId

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -65,7 +65,7 @@ export const convertWorkflowRunsQuery = (query: string): string => {
       // Add entityInputs filter (Mesh can't expose nested argument types?).
       .replace(
         "entityInputs",
-        'entityInputs(where: { entityType: { _eq: "SequencingRead" } })',
+        'entityInputs(where: { entityType: { _eq: "sequencing_read" } })',
       )
   );
 };


### PR DESCRIPTION
# Pull Request

Entity inputs are underscore now.

## Tests

FE doesn't read this field directly (it assumes that the only entity input is for the sequencing read, because we query `entityInputs` with a filter).
