### PR TITLE
feat: query aggregates from NextGen and reformat response

### DIFF
--- a/example-queries/workflows-aggregate-query.graphql
+++ b/example-queries/workflows-aggregate-query.graphql
@@ -7,8 +7,9 @@ query workflowRunsAggregateQuery {
         },
         workflowVersion: {
           workflow: {
-            name: "consensus-genome"
-          }
+            name: 
+              _in: ["consensus-genome"]
+          },
         },
       },
       todoRemove: { 

--- a/example-queries/workflows-aggregate-query.graphql
+++ b/example-queries/workflows-aggregate-query.graphql
@@ -4,17 +4,17 @@ query workflowRunsAggregateQuery {
       where: {
         id: {
           _in: ["1", "2", "3"]
-        },
+        }
         workflowVersion: {
           workflow: {
-            name: 
+            name: {
               _in: ["consensus-genome"]
-          },
-        },
-      },
+            }
+          }
+        }
+      }
       todoRemove: { 
         domain: "my_data",
-        offset: 0,
         visibility: "public",
         search: "abc",
         time: ["20240214", "20240222"]

--- a/example-queries/workflows-aggregate-query.graphql
+++ b/example-queries/workflows-aggregate-query.graphql
@@ -4,7 +4,12 @@ query workflowRunsAggregateQuery {
       where: {
         id: {
           _in: ["1", "2", "3"]
-        } 
+        },
+        workflowVersion: {
+          workflow: {
+            name: "consensus-genome"
+          }
+        },
       },
       todoRemove: { 
         domain: "my_data",
@@ -15,9 +20,16 @@ query workflowRunsAggregateQuery {
       }
     }
   ) {
-    collectionId
-    amrRunsCount
-    cgRunsCount
-    mngsRunsCount
+    aggregate {
+      groupBy {
+        collectionId
+        workflowVersion {
+          workflow {
+            name
+          }
+        }
+      }
+      count
+    }
   }
 }

--- a/json-schemas/workflowRunsAggregateRequest.json
+++ b/json-schemas/workflowRunsAggregateRequest.json
@@ -8,14 +8,9 @@
                     "type": "object",
                     "properties": {
                         "_in": {
-                            "type": "object",
-                            "properties": {
-                                "items": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
+                            "type": "array",
+                            "items": {
+                                "type": "string"
                             }
                         }
                     }
@@ -30,14 +25,9 @@
                                     "type": "object",
                                     "properties": {
                                         "_in": {
-                                            "type": "object",
-                                            "properties": {
-                                                "items": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "string"
-                                                    }
-                                                }
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
                                             }
                                         }
                                     }

--- a/json-schemas/workflowRunsAggregateRequest.json
+++ b/json-schemas/workflowRunsAggregateRequest.json
@@ -8,9 +8,40 @@
                     "type": "object",
                     "properties": {
                         "_in": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "workflowVersion": {
+                    "type": "object",
+                    "properties": {
+                        "workflow": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "object",
+                                            "properties": {
+                                                "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/json-schemas/workflowRunsAggregateResponse.json
+++ b/json-schemas/workflowRunsAggregateResponse.json
@@ -21,16 +21,30 @@
                                             "name": {
                                                 "type": "string"
                                             }
-                                        }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
                                     }
-                                }
+                                },
+                                "required": [
+                                    "workflow"
+                                ]
                             }
-                        }
+                        },
+                        "required": [
+                            "collectionId",
+                            "workflowVersion"
+                        ]
                     },
                     "count": {
                         "type": "integer"
                     }
-                }
+                },
+                "required": [
+                    "groupBy",
+                    "count"
+                ]
             }
         }
     }

--- a/json-schemas/workflowRunsAggregateResponse.json
+++ b/json-schemas/workflowRunsAggregateResponse.json
@@ -1,26 +1,37 @@
 {
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "collectionId": {
-                "type": "string"
-            },
-            "mngsRunsCount": {
-                "type": "integer"
-            },
-            "cgRunsCount": {
-                "type": "integer"
-            },
-            "amrRunsCount": {
-                "type": "integer"
+    "type": "object",
+    "properties": {
+        "aggregate": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "groupBy": {
+                        "type": "object",
+                        "properties": {
+                            "collectionId": {
+                                "type": "integer"
+                            },
+                            "workflowVersion": {
+                                "type": "object",
+                                "properties": {
+                                    "workflow": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "count": {
+                        "type": "integer"
+                    }
+                }
             }
-        },
-        "required": [
-            "collectionId",
-            "mngsRunsCount",
-            "cgRunsCount",
-            "amrRunsCount"
-        ]
+        }
     }
 }

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -6,7 +6,6 @@ import {
   query_fedSamples_items,
   query_fedSequencingReads_items,
   query_fedWorkflowRunsAggregate_aggregate_items,
-  query_fedWorkflowRunsAggregate_items,
   query_fedWorkflowRuns_items,
 } from "./.mesh";
 import { processWorkflowsAggregateResponse } from "./utils/aggregateUtils";
@@ -840,12 +839,12 @@ export const resolvers: Resolvers = {
           await fetchFromNextGen({
             customQuery: convertSequencingReadsQuery(context.params.query),
             customVariables: {
-              where: input.where,
+              where: input?.where,
               // TODO: Migrate to array orderBy.
               orderBy:
-                (input.orderBy != null ? [input.orderBy] : undefined) ??
+                (input?.orderBy != null ? [input.orderBy] : undefined) ??
                 input.orderByArray,
-              limitOffset: input.limitOffset,
+              limitOffset: input?.limitOffset,
               producingRunIds: input.where?.id?._in,
             },
             serviceType: "entities",
@@ -1159,10 +1158,10 @@ export const resolvers: Resolvers = {
         const response = await fetchFromNextGen({
           customQuery: convertWorkflowRunsQuery(context.params.query),
           customVariables: {
-            where: input.where,
+            where: input?.where,
             // TODO: Migrate to array orderBy.
             orderBy:
-              (input.orderBy != null ? [input.orderBy] : undefined) ??
+              (input?.orderBy != null ? [input.orderBy] : undefined) ??
               input.orderByArray,
           },
           serviceType: "workflows",
@@ -1287,7 +1286,7 @@ export const resolvers: Resolvers = {
             where: args.input?.where,
           }
         });
-        nextGenProjectAggregates = consensusGenomesAggregateResponse?.data?.workflowsAggregate?.aggregate;
+        nextGenProjectAggregates = consensusGenomesAggregateResponse?.data?.workflowRunsAggregate?.aggregate;
       }
 
       return processWorkflowsAggregateResponse(nextGenProjectAggregates, projects, nextGenEnabled);

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -1254,28 +1254,28 @@ export const resolvers: Resolvers = {
       });
 
       const nextGenEnabled = await shouldReadFromNextGen(context);
-      const customQuery = 
-      `
-        query nextGenWorkflowsAggregate {
-          workflowRunsAggregate(where: $where) {
-            aggregate {
-              groupBy {
-                collectionId
-                workflowVersion {
-                  workflow {
-                    name
-                  }
-                }
-              }
-              count
-            }
-          }
-        }
-      `;
 
       let nextGenProjectAggregates: query_fedWorkflowRunsAggregate_aggregate_items[] = [];
 
       if (nextGenEnabled) {
+        const customQuery = 
+          `
+            query nextGenWorkflowsAggregate {
+              workflowRunsAggregate(where: $where) {
+                aggregate {
+                  groupBy {
+                    collectionId
+                    workflowVersion {
+                      workflow {
+                        name
+                      }
+                    }
+                  }
+                  count
+                }
+              }
+            }
+          `;
         const consensusGenomesAggregateResponse = await fetchFromNextGen({
           args,
           context,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -1,7 +1,6 @@
 // resolvers.ts
 import {
   Resolvers,
-  fedWorkflowRunsAggregate,
   query_fedConsensusGenomes_items,
   query_fedSamples_items,
   query_fedSequencingReads_items,

--- a/sample-requests/workflowRunsAggregate.json
+++ b/sample-requests/workflowRunsAggregate.json
@@ -6,6 +6,20 @@
           "1234"
         ]
       }
+    },
+    "workflowVersion": {
+      "workflow": {
+        "name": {
+          "_in": {
+            "items": [
+              "consensus-genome",
+              "short-read-mngs",
+              "long-read-mngs",
+              "amr"
+            ]
+          }
+        }
+      }
     }
   },
   "todoRemove": {

--- a/sample-requests/workflowRunsAggregate.json
+++ b/sample-requests/workflowRunsAggregate.json
@@ -1,23 +1,19 @@
 {
   "where": {
     "id": {
-      "_in": {
-        "items": [
-          "1234"
-        ]
-      }
+      "_in": [
+        "1234"
+      ]
     },
     "workflowVersion": {
       "workflow": {
         "name": {
-          "_in": {
-            "items": [
-              "consensus-genome",
-              "short-read-mngs",
-              "long-read-mngs",
-              "amr"
-            ]
-          }
+          "_in": [
+            "consensus-genome",
+            "short-read-mngs",
+            "long-read-mngs",
+            "amr"
+          ]
         }
       }
     }

--- a/sample-responses/workflowRunsAggregate.json
+++ b/sample-responses/workflowRunsAggregate.json
@@ -1,8 +1,26 @@
-[
-  {
-    "collectionId": "123",
-    "mngsRunsCount": 0,
-    "cgRunsCount": 5,
-    "amrRunsCount": 0
-  }
-]
+{
+  "aggregate": [
+    {
+      "groupBy": {
+        "collectionId": 1234,
+        "workflowVersion": {
+          "workflow": {
+            "name": "consensus-genome"
+          }
+        }
+      },
+      "count": 2
+    },
+    {
+      "groupBy": {
+        "collectionId": 1234,
+        "workflowVersion": {
+          "workflow": {
+            "name": "amr"
+          }
+        }
+      },
+      "count": 1
+    }
+  ]
+}

--- a/tests/WorkflowRunsAggregateQuery.test.ts
+++ b/tests/WorkflowRunsAggregateQuery.test.ts
@@ -3,6 +3,7 @@ import { getMeshInstance } from "./utils/MeshInstance";
 
 import * as httpUtils from "../utils/httpUtils";
 import { getExampleQuery } from "./utils/ExampleQueryFiles";
+import { query_fedWorkflowRunsAggregate_aggregate_items } from "../.mesh";
 jest.spyOn(httpUtils, "get");
 
 beforeEach(() => {
@@ -40,10 +41,14 @@ describe("workflows aggregate query:", () => {
       context: expect.anything(),
     });
 
-    expect(response.data.fedWorkflowRunsAggregate).toHaveLength(1);
-    expect(response.data.fedWorkflowRunsAggregate[0].collectionId).toBe("1");
-    expect(response.data.fedWorkflowRunsAggregate[0].amrRunsCount).toBe(2);
-    expect(response.data.fedWorkflowRunsAggregate[0].cgRunsCount).toBe(1);
-    expect(response.data.fedWorkflowRunsAggregate[0].mngsRunsCount).toBe(3);
+    const aggregates: query_fedWorkflowRunsAggregate_aggregate_items[] = response.data.fedWorkflowRunsAggregate.aggregate;
+
+    expect(response.data.fedWorkflowRunsAggregate).toHaveLength(3);
+    const cgAggregate = aggregates.find(aggregate => aggregate.groupBy?.workflowVersion?.workflow?.name === "consensus-genome");
+    expect(cgAggregate?.count).toBe(1);
+    const amrAggregate = aggregates.find(aggregate => aggregate.groupBy?.workflowVersion?.workflow?.name === "amr");
+    expect(amrAggregate?.count).toBe(2);
+    const mngsAggregate = aggregates.find(aggregate => aggregate.groupBy?.workflowVersion?.workflow?.name === "short-read-mngs");
+    expect(mngsAggregate?.count).toBe(3);
   });
 });

--- a/tests/WorkflowRunsAggregateQuery.test.ts
+++ b/tests/WorkflowRunsAggregateQuery.test.ts
@@ -5,6 +5,7 @@ import * as httpUtils from "../utils/httpUtils";
 import { getExampleQuery } from "./utils/ExampleQueryFiles";
 import { query_fedWorkflowRunsAggregate_aggregate_items } from "../.mesh";
 jest.spyOn(httpUtils, "get");
+jest.spyOn(httpUtils, "shouldReadFromNextGen");
 
 beforeEach(() => {
   (httpUtils.get as jest.Mock).mockClear();
@@ -19,6 +20,9 @@ describe("workflows aggregate query:", () => {
   });
 
   it("Returns aggregate counts for each workflow", async () => {
+    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(() =>
+      Promise.resolve(false),
+    );
     (httpUtils.get as jest.Mock).mockImplementation(() => ({
       projects: [
         {
@@ -41,7 +45,7 @@ describe("workflows aggregate query:", () => {
       context: expect.anything(),
     });
 
-    console.log(response.data);
+    console.log(response);
 
     const aggregates: query_fedWorkflowRunsAggregate_aggregate_items[] = response.data.fedWorkflowRunsAggregate.aggregate;
 

--- a/tests/WorkflowRunsAggregateQuery.test.ts
+++ b/tests/WorkflowRunsAggregateQuery.test.ts
@@ -41,9 +41,11 @@ describe("workflows aggregate query:", () => {
       context: expect.anything(),
     });
 
+    console.log(response.data);
+
     const aggregates: query_fedWorkflowRunsAggregate_aggregate_items[] = response.data.fedWorkflowRunsAggregate.aggregate;
 
-    expect(response.data.fedWorkflowRunsAggregate).toHaveLength(3);
+    expect(aggregates).toHaveLength(3);
     const cgAggregate = aggregates.find(aggregate => aggregate.groupBy?.workflowVersion?.workflow?.name === "consensus-genome");
     expect(cgAggregate?.count).toBe(1);
     const amrAggregate = aggregates.find(aggregate => aggregate.groupBy?.workflowVersion?.workflow?.name === "amr");

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -219,7 +219,7 @@ input BoolComparators {
   _gt: Int
   _gte: Int
   _in: [Int!]
-  _is_null: Int
+  _is_null: Boolean
   _lt: Int
   _lte: Int
   _neq: Int
@@ -4867,21 +4867,21 @@ type query_fedSequencingReads_items_taxon {
 }
 
 type query_fedWorkflowRunsAggregate_aggregate_items {
-  count: Int
-  groupBy: query_fedWorkflowRunsAggregate_aggregate_items_groupBy
+  count: Int!
+  groupBy: query_fedWorkflowRunsAggregate_aggregate_items_groupBy!
 }
 
 type query_fedWorkflowRunsAggregate_aggregate_items_groupBy {
-  collectionId: Int
-  workflowVersion: query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion
+  collectionId: Int!
+  workflowVersion: query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion!
 }
 
 type query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion {
-  workflow: query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion_workflow
+  workflow: query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion_workflow!
 }
 
 type query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion_workflow {
-  name: String
+  name: String!
 }
 
 type query_fedWorkflowRuns_items {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -1741,7 +1741,7 @@ type Query {
   fedSamples(input: queryInput_fedSamples_input_Input): [query_fedSamples_items] @httpOperation(subgraph: "CZIDREST", path: "/workflow_runs.json", httpMethod: GET)
   fedSequencingReads(input: queryInput_fedSequencingReads_input_Input): [query_fedSequencingReads_items] @httpOperation(subgraph: "CZIDREST", path: "/workflow_runs.json", httpMethod: GET)
   fedWorkflowRuns(input: queryInput_fedWorkflowRuns_input_Input): [query_fedWorkflowRuns_items] @httpOperation(subgraph: "CZIDREST", path: "/workflow_runs.json", httpMethod: POST)
-  fedWorkflowRunsAggregate(input: queryInput_fedWorkflowRunsAggregate_input_Input): [query_fedWorkflowRunsAggregate_items] @httpOperation(subgraph: "CZIDREST", path: "/projects.json", httpMethod: GET)
+  fedWorkflowRunsAggregate(input: queryInput_fedWorkflowRunsAggregate_input_Input): fedWorkflowRunsAggregate @httpOperation(subgraph: "CZIDREST", path: "/projects.json", httpMethod: GET)
   files(where: FileWhereClause = null): [File!]!
   genomicRanges(limitOffset: LimitOffsetClause = null, orderBy: [GenomicRangeOrderByClause!] = [], where: GenomicRangeWhereClause = null): [GenomicRange!]!
   genomicRangesAggregate(where: GenomicRangeWhereClause = null): GenomicRangeAggregate!
@@ -1915,7 +1915,7 @@ type Sample implements EntityInterface & Node {
   alignmentConfigName: String
   basespaceAccessToken: String
   collectionId: Int!
-  createdAt: DateTime!
+  createdAt: ISO8601DateTime
   dagVars: String
   defaultBackgroundId: Int
   defaultPipelineRunId: Int
@@ -1973,7 +1973,7 @@ type Sample implements EntityInterface & Node {
   sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
   status: String
   subsample: Int
-  updatedAt: DateTime
+  updatedAt: ISO8601DateTime
   uploadError: String
   uploadedFromBasespace: Int
   useTaxonWhitelist: Boolean!
@@ -2981,7 +2981,7 @@ type WorkflowRun implements EntityInterface & Node {
   _id: GlobalID!
   cachedResults: String
   collectionId: Int!
-  createdAt: DateTime!
+  createdAt: ISO8601DateTime!
   deprecated: Boolean!
   endedAt: DateTime
   entityInputs(
@@ -3012,7 +3012,7 @@ type WorkflowRun implements EntityInterface & Node {
   sampleId: Int
   sfnExecutionArn: String
   startedAt: DateTime
-  status: WorkflowRunStatus
+  status: String!
   steps(
     """Returns the items in the list that come after the specified cursor."""
     after: String = null
@@ -3027,7 +3027,7 @@ type WorkflowRun implements EntityInterface & Node {
   ): WorkflowRunStepConnection!
   stepsAggregate(where: WorkflowRunStepWhereClause = null): WorkflowRunStepAggregate
   timeToFinalized: Int
-  updatedAt: DateTime
+  updatedAt: ISO8601DateTime!
   wdlVersion: String
   workflow: String!
   workflowRunnerInputsJson: String
@@ -3639,6 +3639,10 @@ type ZipLink {
   url: String
 }
 
+type fedWorkflowRunsAggregate {
+  aggregate: [query_fedWorkflowRunsAggregate_aggregate_items]
+}
+
 input mutationInput_CreateBulkDownload_input_Input {
   authenticityToken: String
   downloadFormat: String
@@ -4080,9 +4084,22 @@ input queryInput_fedWorkflowRunsAggregate_input_todoRemove_taxonThresholds_items
 
 input queryInput_fedWorkflowRunsAggregate_input_where_Input {
   id: queryInput_fedWorkflowRunsAggregate_input_where_id_Input
+  workflowVersion: queryInput_fedWorkflowRunsAggregate_input_where_workflowVersion_Input
 }
 
 input queryInput_fedWorkflowRunsAggregate_input_where_id_Input {
+  _in: [String]
+}
+
+input queryInput_fedWorkflowRunsAggregate_input_where_workflowVersion_Input {
+  workflow: queryInput_fedWorkflowRunsAggregate_input_where_workflowVersion_workflow_Input
+}
+
+input queryInput_fedWorkflowRunsAggregate_input_where_workflowVersion_workflow_Input {
+  name: queryInput_fedWorkflowRunsAggregate_input_where_workflowVersion_workflow_name_Input
+}
+
+input queryInput_fedWorkflowRunsAggregate_input_where_workflowVersion_workflow_name_Input {
   _in: [String]
 }
 
@@ -4849,11 +4866,22 @@ type query_fedSequencingReads_items_taxon {
   name: String!
 }
 
-type query_fedWorkflowRunsAggregate_items {
-  amrRunsCount: Int!
-  cgRunsCount: Int!
-  collectionId: String!
-  mngsRunsCount: Int!
+type query_fedWorkflowRunsAggregate_aggregate_items {
+  count: Int
+  groupBy: query_fedWorkflowRunsAggregate_aggregate_items_groupBy
+}
+
+type query_fedWorkflowRunsAggregate_aggregate_items_groupBy {
+  collectionId: Int
+  workflowVersion: query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion
+}
+
+type query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion {
+  workflow: query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion_workflow
+}
+
+type query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion_workflow {
+  name: String
 }
 
 type query_fedWorkflowRuns_items {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -219,7 +219,7 @@ input BoolComparators {
   _gt: Int
   _gte: Int
   _in: [Int!]
-  _is_null: Int
+  _is_null: Boolean
   _lt: Int
   _lte: Int
   _neq: Int

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -219,7 +219,7 @@ input BoolComparators {
   _gt: Int
   _gte: Int
   _in: [Int!]
-  _is_null: Boolean
+  _is_null: Int
   _lt: Int
   _lte: Int
   _neq: Int
@@ -1915,7 +1915,7 @@ type Sample implements EntityInterface & Node {
   alignmentConfigName: String
   basespaceAccessToken: String
   collectionId: Int!
-  createdAt: DateTime!
+  createdAt: ISO8601DateTime
   dagVars: String
   defaultBackgroundId: Int
   defaultPipelineRunId: Int
@@ -1973,7 +1973,7 @@ type Sample implements EntityInterface & Node {
   sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
   status: String
   subsample: Int
-  updatedAt: DateTime
+  updatedAt: ISO8601DateTime
   uploadError: String
   uploadedFromBasespace: Int
   useTaxonWhitelist: Boolean!
@@ -2981,7 +2981,7 @@ type WorkflowRun implements EntityInterface & Node {
   _id: GlobalID!
   cachedResults: String
   collectionId: Int!
-  createdAt: DateTime!
+  createdAt: ISO8601DateTime!
   deprecated: Boolean!
   endedAt: DateTime
   entityInputs(
@@ -3012,7 +3012,7 @@ type WorkflowRun implements EntityInterface & Node {
   sampleId: Int
   sfnExecutionArn: String
   startedAt: DateTime
-  status: WorkflowRunStatus
+  status: String!
   steps(
     """Returns the items in the list that come after the specified cursor."""
     after: String = null
@@ -3027,7 +3027,7 @@ type WorkflowRun implements EntityInterface & Node {
   ): WorkflowRunStepConnection!
   stepsAggregate(where: WorkflowRunStepWhereClause = null): WorkflowRunStepAggregate
   timeToFinalized: Int
-  updatedAt: DateTime
+  updatedAt: ISO8601DateTime!
   wdlVersion: String
   workflow: String!
   workflowRunnerInputsJson: String

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -1915,7 +1915,7 @@ type Sample implements EntityInterface & Node {
   alignmentConfigName: String
   basespaceAccessToken: String
   collectionId: Int!
-  createdAt: ISO8601DateTime
+  createdAt: DateTime!
   dagVars: String
   defaultBackgroundId: Int
   defaultPipelineRunId: Int
@@ -1973,7 +1973,7 @@ type Sample implements EntityInterface & Node {
   sequencingReadsAggregate(where: SequencingReadWhereClause = null): SequencingReadAggregate
   status: String
   subsample: Int
-  updatedAt: ISO8601DateTime
+  updatedAt: DateTime
   uploadError: String
   uploadedFromBasespace: Int
   useTaxonWhitelist: Boolean!
@@ -2981,7 +2981,7 @@ type WorkflowRun implements EntityInterface & Node {
   _id: GlobalID!
   cachedResults: String
   collectionId: Int!
-  createdAt: ISO8601DateTime!
+  createdAt: DateTime!
   deprecated: Boolean!
   endedAt: DateTime
   entityInputs(
@@ -3012,7 +3012,7 @@ type WorkflowRun implements EntityInterface & Node {
   sampleId: Int
   sfnExecutionArn: String
   startedAt: DateTime
-  status: String!
+  status: WorkflowRunStatus
   steps(
     """Returns the items in the list that come after the specified cursor."""
     after: String = null
@@ -3027,7 +3027,7 @@ type WorkflowRun implements EntityInterface & Node {
   ): WorkflowRunStepConnection!
   stepsAggregate(where: WorkflowRunStepWhereClause = null): WorkflowRunStepAggregate
   timeToFinalized: Int
-  updatedAt: ISO8601DateTime!
+  updatedAt: DateTime
   wdlVersion: String
   workflow: String!
   workflowRunnerInputsJson: String

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -219,7 +219,7 @@ input BoolComparators {
   _gt: Int
   _gte: Int
   _in: [Int!]
-  _is_null: Boolean
+  _is_null: Int
   _lt: Int
   _lte: Int
   _neq: Int

--- a/utils/aggregateUtils.ts
+++ b/utils/aggregateUtils.ts
@@ -26,7 +26,7 @@ export const processWorkflowsAggregateResponse = (
       aggregate =>
         aggregate?.groupBy?.workflowVersion?.workflow?.name ===
           "consensus-genome" && aggregate?.groupBy?.collectionId === project.id,
-    );
+    )?.count || 0;
     const counts = {
       "short-read-mngs": project.sample_counts.mngs_runs_count,
       "consensus-genome": nextGenEnabled ? nextGenCgCount : project.sample_counts.cg_runs_count,

--- a/utils/aggregateUtils.ts
+++ b/utils/aggregateUtils.ts
@@ -1,0 +1,51 @@
+import { fedWorkflowRunsAggregate, query_fedWorkflowRunsAggregate_aggregate_items } from "../.mesh";
+
+type RailsProjectAggregate = {
+  id: number;
+  sample_counts: {
+    mngs_runs_count: number;
+    cg_runs_count: number;
+    amr_runs_count: number;
+  };
+};
+
+// combine the aggregate counts from rails and next gen into a single response
+// that looks like a GraphQL aggregate query response
+export const processWorkflowsAggregateResponse = (
+  nextGenProjectAggregates: query_fedWorkflowRunsAggregate_aggregate_items[] | null,
+  railsProjects: RailsProjectAggregate[], 
+  nextGenEnabled: boolean
+): fedWorkflowRunsAggregate => {
+  const aggregates: fedWorkflowRunsAggregate = {
+    "aggregate": [],
+  }
+
+  for (const project of railsProjects) {
+    // TODO: enable more workflows coming from next gen
+    const nextGenCgCount = nextGenProjectAggregates?.find(
+      aggregate =>
+        aggregate?.groupBy?.workflowVersion?.workflow?.name ===
+          "consensus-genome" && aggregate?.groupBy?.collectionId === project.id,
+    );
+    const counts = {
+      "short-read-mngs": project.sample_counts.mngs_runs_count,
+      "consensus-genome": nextGenEnabled ? nextGenCgCount : project.sample_counts.cg_runs_count,
+      "amr": project.sample_counts.amr_runs_count,
+    }
+    for (const workflow of ["consensus-genome", "short-read-mngs", "amr"]) {
+      aggregates?.aggregate?.push({
+        "groupBy": {
+          "workflowVersion": {
+            "workflow": {
+              "name": workflow,
+            },
+          },
+          "collectionId": project.id,
+        },
+        "count": counts[workflow],
+      });
+    }
+  }
+
+  return aggregates;
+}

--- a/utils/aggregateUtils.ts
+++ b/utils/aggregateUtils.ts
@@ -32,7 +32,6 @@ export const processWorkflowsAggregateResponse = (
       "consensus-genome": nextGenEnabled ? nextGenCgCount : project.sample_counts.cg_runs_count,
       "amr": project.sample_counts.amr_runs_count,
     }
-    console.log(counts)
     for (const workflow of ["consensus-genome", "short-read-mngs", "amr"]) {
       aggregates?.aggregate?.push({
         "groupBy": {

--- a/utils/aggregateUtils.ts
+++ b/utils/aggregateUtils.ts
@@ -32,6 +32,7 @@ export const processWorkflowsAggregateResponse = (
       "consensus-genome": nextGenEnabled ? nextGenCgCount : project.sample_counts.cg_runs_count,
       "amr": project.sample_counts.amr_runs_count,
     }
+    console.log(counts)
     for (const workflow of ["consensus-genome", "short-read-mngs", "amr"]) {
       aggregates?.aggregate?.push({
         "groupBy": {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9419]

## Description

Query CG runs from next gen and make the response look next-gen-y

## Notes

- writing endpoint so that we can either make one aggregate query per workflow (e.g. CG, AMR, mNGS each hit the aggregate endpoint) or we just do one big query by joining all the workflow run ids together. This way we can change the frontend without changing the federation layer.
- it's sort of convoluted to process the rails data into the `groupBy` format and then unprocess it into a usable format on the frontend but it fits into how the response will ultimately look on the FE

## Tests

Hit endpoint from GraphiQL and from frontend code successfully. Ran NextGen query in staging and confirmed it returned correct results.


[CZID-9306]: https://czi-tech.atlassian.net/browse/CZID-9306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CZID-9419]: https://czi-tech.atlassian.net/browse/CZID-9419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ