### PR TITLE
fix: Don't call Rails for the join if there were no sequencing reads returned by NextGen

### DIFF
--- a/resolvers.ts
+++ b/resolvers.ts
@@ -838,14 +838,19 @@ export const resolvers: Resolvers = {
             context,
           })
         ).data.sequencingReads;
+        const railsSampleIds = nextGenSequencingReads
+          .map(sequencingRead => sequencingRead.sample.railsSampleId)
+          .filter(id => id != null);
+        if (railsSampleIds.length === 0) {
+          return [];
+        }
+
         const railsSamples = (
           await getFromRails({
             url:
               "/samples/index_v2.json" +
               formatUrlParams({
-                sampleIds: nextGenSequencingReads.map(
-                  sequencingRead => sequencingRead.sample.railsSampleId,
-                ),
+                sampleIds: railsSampleIds,
                 limit: TEN_MILLION,
                 offset: 0,
                 listAllIds: false,

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -619,4 +619,23 @@ describe("sequencingReads query:", () => {
       }),
     ]);
   });
+
+  it("Does not call Rails to do join if no NextGen data returned", async () => {
+    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(() =>
+      Promise.resolve(true),
+    );
+    (httpUtils.fetchFromNextGen as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          sequencingReads: [],
+        },
+      }),
+    );
+
+    const sequencingReads = (await execute(query, {}, { params: { query } }))
+      .data.fedSequencingReads;
+
+    expect(sequencingReads).toEqual([]);
+    expect(httpUtils.getFromRails as jest.Mock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
# Pull Request

Ideally this would've never happened, but currently we have `WorkflowRun`s that point to non-existent `SequencingRead`s in staging. We never want to send no `sampleIds` to Rails, otherwise it will join every `Sample` ever.

## Tests

Staging should stop lagging.
