### PR TITLE
fix: Add sample uploader name to joined data from Rails + Use new array orderBy argument for NextGen

### DIFF
--- a/example-queries/workflow-runs-query-order-by-array.graphql
+++ b/example-queries/workflow-runs-query-order-by-array.graphql
@@ -1,0 +1,21 @@
+query TestQuery {
+    fedWorkflowRuns(input: {
+        orderByArray: [{
+            startedAt: "asc"
+        }],
+        todoRemove: {
+            orderBy: "createdAt"
+            orderDir: "ASC"
+        }
+    }) {
+        id
+        entityInputs {
+            edges {
+                node {
+                    fieldName
+                    inputEntityId
+                }
+            }
+        }
+    }
+}

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -1091,14 +1091,7 @@ export const resolvers: Resolvers = {
         pipelineVersion: args.workflowVersionId,
         merge_nt_nr: false,
       });
-      const {
-        _all_tax_ids,
-        _metadata,
-        counts,
-        _lineage,
-        _sortedGenus,
-        _highlightedTaxIds,
-      } =
+      const { counts } =
         (await get({
           url: `/samples/${args.sampleId}/report_v2` + urlParams,
           args,
@@ -1120,7 +1113,7 @@ export const resolvers: Resolvers = {
       });
       return annotations;
     },
-    fedWorkflowRuns: async (root, args, context: any) => {
+    fedWorkflowRuns: async (_, args, context: any) => {
       const input = args.input;
       if (input == null) {
         throw new Error("fedWorkflowRuns input is nullish");

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -816,6 +816,9 @@ export const resolvers: Resolvers = {
     },
     fedSequencingReads: async (root, args, context: any) => {
       const input = args.input;
+      if (input == null) {
+        throw new Error("fedSequencingReads input is nullish");
+      }
 
       // NEXT GEN:
       const nextGenEnabled = await shouldReadFromNextGen(context);
@@ -825,9 +828,12 @@ export const resolvers: Resolvers = {
             customQuery: convertSequencingReadsQuery(context.params.query),
             customVariables: {
               where: input.where,
-              orderBy: input.orderBy != null ? [input.orderBy] : [], // TODO: Migrate to array orderBy.
+              // TODO: Migrate to array orderBy.
+              orderBy:
+                (input.orderBy != null ? [input.orderBy] : undefined) ??
+                input.orderByArray,
               limitOffset: input.limitOffset,
-              producingRunIds: input?.where?.id?._in,
+              producingRunIds: input.where?.id?._in,
             },
             serviceType: "entities",
             args,
@@ -897,27 +903,27 @@ export const resolvers: Resolvers = {
             mode: "with_sample_info",
             //  - DiscoveryDataLayer.ts
             //    await this._collection.fetchDataCallback({
-            domain: input?.todoRemove?.domain,
+            domain: input.todoRemove?.domain,
             //  -- DiscoveryView.tsx
             //     ...this.getConditions(workflow)
-            projectId: input?.todoRemove?.projectId,
-            search: input?.todoRemove?.search,
-            orderBy: input?.todoRemove?.orderBy,
-            orderDir: input?.todoRemove?.orderDir,
+            projectId: input.todoRemove?.projectId,
+            search: input.todoRemove?.search,
+            orderBy: input.todoRemove?.orderBy,
+            orderDir: input.todoRemove?.orderDir,
             //  --- DiscoveryView.tsx
             //      filters: {
-            host: input?.todoRemove?.host,
-            locationV2: input?.todoRemove?.locationV2,
-            taxon: input?.todoRemove?.taxons,
-            taxaLevels: input?.todoRemove?.taxaLevels,
-            time: input?.todoRemove?.time,
-            tissue: input?.todoRemove?.tissue,
-            visibility: input?.todoRemove?.visibility,
-            workflow: input?.todoRemove?.workflow,
+            host: input.todoRemove?.host,
+            locationV2: input.todoRemove?.locationV2,
+            taxon: input.todoRemove?.taxons,
+            taxaLevels: input.todoRemove?.taxaLevels,
+            time: input.todoRemove?.time,
+            tissue: input.todoRemove?.tissue,
+            visibility: input.todoRemove?.visibility,
+            workflow: input.todoRemove?.workflow,
             //  - DiscoveryDataLayer.ts
             //    await this._collection.fetchDataCallback({
-            limit: input?.limit ?? input?.limitOffset?.limit, // TODO: Just use limitOffset.
-            offset: input?.offset ?? input?.limitOffset?.offset,
+            limit: input.limit ?? input.limitOffset?.limit, // TODO: Just use limitOffset.
+            offset: input.offset ?? input.limitOffset?.offset,
             listAllIds: false,
           }),
         args,
@@ -1116,13 +1122,16 @@ export const resolvers: Resolvers = {
     },
     fedWorkflowRuns: async (root, args, context: any) => {
       const input = args.input;
+      if (input == null) {
+        throw new Error("fedWorkflowRuns input is nullish");
+      }
 
       // CG REPORT:
       // If we provide a list of workflowRunIds, we assume that this is for getting valid consensus genome workflow runs.
       // This endpoint only provides id, ownerUserId, and status.
-      if (input?.where?.id?._in && typeof input?.where?.id?._in === "object") {
+      if (input.where?.id?._in && typeof input.where?.id?._in === "object") {
         const body = {
-          authenticity_token: input?.todoRemove?.authenticityToken,
+          authenticity_token: input.todoRemove?.authenticityToken,
           workflowRunIds: input.where.id._in.map(id => id && parseInt(id)),
         };
         const { workflowRuns } = await postWithCSRF({
@@ -1145,7 +1154,10 @@ export const resolvers: Resolvers = {
           customQuery: convertWorkflowRunsQuery(context.params.query),
           customVariables: {
             where: input.where,
-            orderBy: input.orderBy != null ? [input.orderBy] : [], // TODO: Migrate to array orderBy.
+            // TODO: Migrate to array orderBy.
+            orderBy:
+              (input.orderBy != null ? [input.orderBy] : undefined) ??
+              input.orderByArray,
           },
           serviceType: "workflows",
           args,
@@ -1161,19 +1173,19 @@ export const resolvers: Resolvers = {
           "/workflow_runs.json" +
           formatUrlParams({
             mode: "basic",
-            domain: input?.todoRemove?.domain,
-            projectId: input?.todoRemove?.projectId,
-            search: input?.todoRemove?.search,
-            orderBy: input?.todoRemove?.orderBy,
-            orderDir: input?.todoRemove?.orderDir,
-            host: input?.todoRemove?.host,
-            locationV2: input?.todoRemove?.locationV2,
-            taxon: input?.todoRemove?.taxon,
-            taxaLevels: input?.todoRemove?.taxonLevels,
-            time: input?.todoRemove?.time,
-            tissue: input?.todoRemove?.tissue,
-            visibility: input?.todoRemove?.visibility,
-            workflow: input?.todoRemove?.workflow,
+            domain: input.todoRemove?.domain,
+            projectId: input.todoRemove?.projectId,
+            search: input.todoRemove?.search,
+            orderBy: input.todoRemove?.orderBy,
+            orderDir: input.todoRemove?.orderDir,
+            host: input.todoRemove?.host,
+            locationV2: input.todoRemove?.locationV2,
+            taxon: input.todoRemove?.taxon,
+            taxaLevels: input.todoRemove?.taxonLevels,
+            time: input.todoRemove?.time,
+            tissue: input.todoRemove?.tissue,
+            visibility: input.todoRemove?.visibility,
+            workflow: input.todoRemove?.workflow,
             limit: TEN_MILLION,
             offset: 0,
             listAllIds: false,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -492,8 +492,9 @@ export const resolvers: Resolvers = {
         );
         sampleInfo.pipeline_runs = updatedPipelineRuns;
       }
-      if (sampleInfo?.default_pipeline_run_id){
-        sampleInfo.default_pipeline_run_id = sampleInfo.default_pipeline_run_id.toString();
+      if (sampleInfo?.default_pipeline_run_id) {
+        sampleInfo.default_pipeline_run_id =
+          sampleInfo.default_pipeline_run_id.toString();
       }
       if (sampleInfo?.workflow_runs) {
         const updatedWorkflowRuns = sampleInfo?.workflow_runs.map(
@@ -872,6 +873,7 @@ export const resolvers: Resolvers = {
           nextGenSample.waterControl = railsMetadata?.water_control === "Yes";
           nextGenSample.notes = railsDbSample?.sample_notes;
           nextGenSample.uploadError = railsDbSample?.upload_error;
+          nextGenSample.ownerUserName = railsSample.details?.uploader?.name;
           nextGenSample.collection = {
             name: railsSample.details?.derived_sample_output?.project_name,
             public: railsSample.public === 1,

--- a/tests/WorkflowRunsQuery.test.ts
+++ b/tests/WorkflowRunsQuery.test.ts
@@ -167,6 +167,23 @@ describe("workflowRuns query:", () => {
     );
   });
 
+  it("Uses orderBy array field for NextGen", async () => {
+    const query = getExampleQuery("workflow-runs-query-order-by-array");
+    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(() =>
+      Promise.resolve(true),
+    );
+
+    await execute(query, {}, { params: { query } });
+
+    expect(httpUtils.fetchFromNextGen as jest.Mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customVariables: expect.objectContaining({
+          orderBy: [{ startedAt: "asc" }],
+        }),
+      }),
+    );
+  });
+
   describe("validConsensusGenomes query", () => {
     it("should call the correct rails endpoint", async () => {
       await execute(getExampleQuery("workflow-runs-query-id-list"), {

--- a/tests/WorkflowRunsQuery.test.ts
+++ b/tests/WorkflowRunsQuery.test.ts
@@ -8,11 +8,13 @@ import { convertWorkflowRunsQuery } from "../utils/queryFormatUtils";
 jest.spyOn(httpUtils, "get");
 jest.spyOn(httpUtils, "postWithCSRF");
 jest.spyOn(httpUtils, "shouldReadFromNextGen");
+jest.spyOn(httpUtils, "fetchFromNextGen");
 
 beforeEach(() => {
   (httpUtils.get as jest.Mock).mockClear();
   (httpUtils.postWithCSRF as jest.Mock).mockClear();
   (httpUtils.shouldReadFromNextGen as jest.Mock).mockClear();
+  (httpUtils.fetchFromNextGen as jest.Mock).mockClear();
 });
 
 describe("workflowRuns query:", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "importHelpers": true,
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "declaration": false,
+    "jsx": "react",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "noImplicitReturns": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "outDir": "build",
+    "removeComments": false,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strictNullChecks": true,
+    "target": "esnext",
+    "baseUrl": "src",
+    "paths": {
+      "/*": [
+        "./*",
+      ],
+    }
+  },
+  "include": [
+    ".",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,8 @@
     "moduleResolution": "node",
     "noImplicitAny": false,
     "noImplicitReturns": false,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noEmit": true,
     "outDir": "build",
     "removeComments": false,
@@ -24,16 +24,5 @@
     "strictNullChecks": true,
     "target": "esnext",
     "baseUrl": "src",
-    "paths": {
-      "/*": [
-        "./*",
-      ],
-    }
   },
-  "include": [
-    ".",
-  ],
-  "exclude": [
-    "node_modules"
-  ]
 }

--- a/utils/enrichToken.ts
+++ b/utils/enrichToken.ts
@@ -2,24 +2,24 @@ const getCzidServicesTokenFromCookie = (httpCookieStr: string) => {
   const tokenKeyVal = httpCookieStr
     .split(";")
     .map((keyValStr: string) => keyValStr.split("="))
-    .map((keyValArr: [string, string]) => ([
+    .map((keyValArr: [string, string]) => [
       decodeURIComponent(keyValArr[0].trim()),
       decodeURIComponent(keyValArr[1].trim()),
-    ]))
-    .find((keyValArr) => keyValArr[0] === "czid_services_token");
+    ])
+    .find(keyValArr => keyValArr[0] === "czid_services_token");
 
   return tokenKeyVal ? tokenKeyVal[1] : null;
-}
+};
 
 export interface ResolverContext {
   request: {
-    headers: Headers
-  }
+    headers: Headers;
+  };
 }
 
 export const getEnrichedToken = async (context: ResolverContext) => {
   const headers = context.request.headers;
-  const httpCookieStr = headers.get("cookie");
+  const httpCookieStr = headers.get("cookie") ?? "";
 
   const czidServicesToken = getCzidServicesTokenFromCookie(httpCookieStr);
 
@@ -33,7 +33,7 @@ export const getEnrichedToken = async (context: ResolverContext) => {
     const enrichedTokenResp = await fetch(enrichTokenURL, {
       method: "GET",
       headers: {
-        Cookie: context.request.headers.get("cookie"),
+        Cookie: context.request.headers.get("cookie") ?? "",
         "Content-Type": "application/json",
         Authorization: `Bearer ${czidServicesToken}`,
       },
@@ -49,4 +49,4 @@ export const getEnrichedToken = async (context: ResolverContext) => {
   } catch (e) {
     console.error("Error while retrieving enriched token", e);
   }
-}
+};


### PR DESCRIPTION
# Pull Request

FE is now using `orderByArray` so that's what we should be sending to NextGen.

In prod today, we technically show the name of the workflow runner, and if that doesn't exist we fall back to the name of the sample uploader. Showing that in NextGen would require us to add a join to Rails in `fedWorkflowRuns`, which may not be worth doing right now given the effort and additional latency that would incur. I've created a Jira to track it for now: https://czi-tech.atlassian.net/browse/CZID-9467

Also add a tsconfig.json to Fed because apparently we didn't have one (and as a result of this, now VSCode is properly saying some variables are possibly undefined, so fix those)!

## Tests

A name should appear in the "Sample" column in the CG table in NextGen.
CG runs should be default sorted by time in NextGen.
