### PR TITLE
fix: return rails data when no nextgen id available

### DIFF
--- a/resolvers.ts
+++ b/resolvers.ts
@@ -587,11 +587,18 @@ export const resolvers: Resolvers = {
       });
       console.log("entitiesResp - get 1", JSON.stringify(entitiesResp));
 
-      // Query workflows using NextGenSampleId to get in progress CG workflow runs
+      // Non-WGS workflows will not have nextGenSampleId. In this case, return sampleInfo from Rails.
       const nextGenSampleId = entitiesResp?.data.samples?.[0]?.id;
       if (!nextGenSampleId) {
-        throw new Error(`No NextGenSampleId found for railsSampleId: ${args.railsSampleId}`);
+        console.log(`No NextGenSampleId found for railsSampleId: ${args.railsSampleId}`);
+        return {
+          id: args.railsSampleId,
+          railsSampleId: args.railsSampleId,
+          ...sampleInfo,
+        };
       }
+
+      // Query workflows using NextGenSampleId to get in progress CG workflow runs
       const workflowsQuery = `
           query WorkflowsQuery {
             workflowRuns(where: {entityInputs: {inputEntityId: {_eq: "${nextGenSampleId}"}}}) {

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -588,7 +588,10 @@ export const resolvers: Resolvers = {
       console.log("entitiesResp - get 1", JSON.stringify(entitiesResp));
 
       // Query workflows using NextGenSampleId to get in progress CG workflow runs
-      const nextGenSampleId = entitiesResp?.data.samples[0].id;
+      const nextGenSampleId = entitiesResp?.data.samples?.[0]?.id;
+      if (!nextGenSampleId) {
+        throw new Error(`No NextGenSampleId found for railsSampleId: ${args.railsSampleId}`);
+      }
       const workflowsQuery = `
           query WorkflowsQuery {
             workflowRuns(where: {entityInputs: {inputEntityId: {_eq: "${nextGenSampleId}"}}}) {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket
none

## Description
For non-wgs workflow runs and non-migrated workflow runs, this should just return the data from rails rather than crashing.  This is expected for workflowRuns/pipelineRuns that are not WGS and for data that hasn't migrated yet.


