### PR TITLE
fix: Use workflowRun IDs in inner consensusGenomes where, not sequencingRead IDs

### DIFF
--- a/example-queries/sequencing-reads-query-fe.graphql
+++ b/example-queries/sequencing-reads-query-fe.graphql
@@ -1,0 +1,66 @@
+query DiscoveryViewFCSequencingReadsQuery(
+    $input: queryInput_fedSequencingReads_input_Input
+) {
+    fedSequencingReads(input: $input) {
+        id
+        nucleicAcid
+        protocol
+        medakaModel
+        technology
+        taxon {
+            name
+        }
+        sample {
+            railsSampleId
+            name
+            notes
+            collectionLocation
+            sampleType
+            waterControl
+            uploadError
+            hostOrganism {
+                name
+            }
+            collection {
+                name
+                public
+            }
+            ownerUserId
+            ownerUserName
+            metadatas {
+                edges {
+                    node {
+                        fieldName
+                        value
+                    }
+                }
+            }
+        }
+        consensusGenomes {
+            edges {
+                node {
+                    producingRunId
+                    taxon {
+                        name
+                    }
+                    accession {
+                        accessionId
+                        accessionName
+                    }
+                    metrics {
+                        coverageDepth
+                        totalReads
+                        gcPercent
+                        refSnps
+                        percentIdentity
+                        nActg
+                        percentGenomeCalled
+                        nMissing
+                        nAmbiguous
+                        referenceGenomeLength
+                    }
+                }
+            }
+        }
+    }
+}

--- a/example-queries/sequencing-reads-query-id-fe.graphql
+++ b/example-queries/sequencing-reads-query-id-fe.graphql
@@ -1,0 +1,7 @@
+query DiscoveryViewFCSequencingReadsQuery(
+    $input: queryInput_fedSequencingReads_input_Input
+) {
+    fedSequencingReads(input: $input) {
+        id
+    }
+}

--- a/example-queries/workflow-runs-query-fe.graphql
+++ b/example-queries/workflow-runs-query-fe.graphql
@@ -1,0 +1,24 @@
+query DiscoveryViewFCWorkflowsQuery(
+    $input: queryInput_fedWorkflowRuns_input_Input
+) {
+    fedWorkflowRuns(input: $input) {
+        id
+        startedAt
+        status
+        rawInputsJson
+        workflowVersion {
+            version
+            workflow {
+                name
+            }
+        }
+        entityInputs {
+            edges {
+                node {
+                inputEntityId
+                entityType
+                }
+            }
+        }
+    }
+}

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -592,7 +592,9 @@ export const resolvers: Resolvers = {
       // Non-WGS workflows will not have nextGenSampleId. In this case, return sampleInfo from Rails.
       const nextGenSampleId = entitiesResp?.data.samples?.[0]?.id;
       if (!nextGenSampleId) {
-        console.log(`No NextGenSampleId found for railsSampleId: ${args.railsSampleId}`);
+        console.log(
+          `No NextGenSampleId found for railsSampleId: ${args.railsSampleId}`,
+        );
         return {
           id: args.railsSampleId,
           railsSampleId: args.railsSampleId,
@@ -838,13 +840,14 @@ export const resolvers: Resolvers = {
           await fetchFromNextGen({
             customQuery: convertSequencingReadsQuery(context.params.query),
             customVariables: {
-              where: input?.where,
+              where: input.where,
               // TODO: Migrate to array orderBy.
               orderBy:
-                (input?.orderBy != null ? [input.orderBy] : undefined) ??
+                (input.orderBy != null ? [input.orderBy] : undefined) ??
                 input.orderByArray,
-              limitOffset: input?.limitOffset,
-              producingRunIds: input.where?.id?._in,
+              limitOffset: input.limitOffset,
+              producingRunIds:
+                input.consensusGenomesInput?.where?.producingRunId?._in,
             },
             serviceType: "entities",
             args,
@@ -1157,10 +1160,10 @@ export const resolvers: Resolvers = {
         const response = await fetchFromNextGen({
           customQuery: convertWorkflowRunsQuery(context.params.query),
           customVariables: {
-            where: input?.where,
+            where: input.where,
             // TODO: Migrate to array orderBy.
             orderBy:
-              (input?.orderBy != null ? [input.orderBy] : undefined) ??
+              (input.orderBy != null ? [input.orderBy] : undefined) ??
               input.orderByArray,
           },
           serviceType: "workflows",
@@ -1255,11 +1258,11 @@ export const resolvers: Resolvers = {
 
       const nextGenEnabled = await shouldReadFromNextGen(context);
 
-      let nextGenProjectAggregates: query_fedWorkflowRunsAggregate_aggregate_items[] = [];
+      let nextGenProjectAggregates: query_fedWorkflowRunsAggregate_aggregate_items[] =
+        [];
 
       if (nextGenEnabled) {
-        const customQuery = 
-          `
+        const customQuery = `
             query nextGenWorkflowsAggregate {
               workflowRunsAggregate(where: $where) {
                 aggregate {
@@ -1283,12 +1286,18 @@ export const resolvers: Resolvers = {
           customQuery,
           customVariables: {
             where: args.input?.where,
-          }
+          },
         });
-        nextGenProjectAggregates = consensusGenomesAggregateResponse?.data?.workflowRunsAggregate?.aggregate;
+        nextGenProjectAggregates =
+          consensusGenomesAggregateResponse?.data?.workflowRunsAggregate
+            ?.aggregate;
       }
 
-      return processWorkflowsAggregateResponse(nextGenProjectAggregates, projects, nextGenEnabled);
+      return processWorkflowsAggregateResponse(
+        nextGenProjectAggregates,
+        projects,
+        nextGenEnabled,
+      );
     },
     ZipLink: async (root, args, context, info) => {
       /* --------------------- Next Gen ------------------------- */

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -601,15 +601,6 @@ describe("sequencingReads query:", () => {
       }),
     );
 
-    console.log(
-      JSON.stringify(
-        await execute(
-          query,
-          { input: { where: { collectionId: { _in: [123] } } } },
-          { params: { query } },
-        ),
-      ),
-    );
     const sequencingReads = (
       await execute(
         query,

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -332,77 +332,9 @@ describe("sequencingReads query:", () => {
     );
   });
 
-  it("Constructs correct NextGen query", () => {
-    const query = `
-      query DiscoveryViewFCSequencingReadsQuery(
-        $input: queryInput_fedSequencingReads_input_Input
-      ) {
-        fedSequencingReads(input: $input) {
-          id
-          nucleicAcid
-          protocol
-          medakaModel
-          technology
-          taxon {
-            name
-          }
-          sample {
-            railsSampleId
-            name
-            notes
-            collectionLocation
-            sampleType
-            waterControl
-            uploadError
-            hostOrganism {
-              name
-            }
-            collection {
-              name
-              public
-            }
-            ownerUserId
-            ownerUserName
-            metadatas {
-              edges {
-                node {
-                  fieldName
-                  value
-                }
-              }
-            }
-          }
-          consensusGenomes {
-            edges {
-              node {
-                producingRunId
-                taxon {
-                  name
-                }
-                accession {
-                  accessionId
-                  accessionName
-                }
-                metrics {
-                  coverageDepth
-                  totalReads
-                  gcPercent
-                  refSnps
-                  percentIdentity
-                  nActg
-                  percentGenomeCalled
-                  nMissing
-                  nAmbiguous
-                  referenceGenomeLength
-                }
-              }
-            }
-          }
-        }
-      }`;
-
+  it("Constructs correct NextGen paginated query", () => {
     assertEqualsNoWhitespace(
-      convertSequencingReadsQuery(query),
+      convertSequencingReadsQuery(getExampleQuery("sequencing-reads-query-fe")),
       `query ($where: SequencingReadWhereClause,
               $orderBy: [SequencingReadOrderByClause!],
               $limitOffset: LimitOffsetClause,
@@ -457,6 +389,19 @@ describe("sequencingReads query:", () => {
               }
             }
           }
+        }
+      }`,
+    );
+  });
+
+  it("Constructs correct NextGen IDs query", () => {
+    assertEqualsNoWhitespace(
+      convertSequencingReadsQuery(
+        getExampleQuery("sequencing-reads-query-id-fe"),
+      ),
+      `query ($where: SequencingReadWhereClause) {
+        sequencingReads(where: $where) {
+          id
         }
       }`,
     );
@@ -636,6 +581,44 @@ describe("sequencingReads query:", () => {
       .data.fedSequencingReads;
 
     expect(sequencingReads).toEqual([]);
+    expect(httpUtils.getFromRails as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("Does not call Rails to do join if only querying IDs", async () => {
+    const query = getExampleQuery("sequencing-reads-query-id-fe");
+    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(() =>
+      Promise.resolve(true),
+    );
+    (httpUtils.fetchFromNextGen as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          sequencingReads: [
+            {
+              id: "abc",
+            },
+          ],
+        },
+      }),
+    );
+
+    console.log(
+      JSON.stringify(
+        await execute(
+          query,
+          { input: { where: { collectionId: { _in: [123] } } } },
+          { params: { query } },
+        ),
+      ),
+    );
+    const sequencingReads = (
+      await execute(
+        query,
+        { input: { where: { id: { _in: ["abc"] } } } },
+        { params: { query } },
+      )
+    ).data.fedSequencingReads;
+
+    expect(sequencingReads).toEqual([{ id: "abc" }]);
     expect(httpUtils.getFromRails as jest.Mock).not.toHaveBeenCalled();
   });
 });

--- a/tests/WorkflowRunsQuery.test.ts
+++ b/tests/WorkflowRunsQuery.test.ts
@@ -116,34 +116,8 @@ describe("workflowRuns query:", () => {
   });
 
   it("Constructs correct NextGen query", async () => {
-    const query = `
-      query DiscoveryViewFCWorkflowsQuery(
-        $input: queryInput_fedWorkflowRuns_input_Input
-      ) {
-        fedWorkflowRuns(input: $input) {
-          id
-          startedAt
-          status
-          rawInputsJson
-          workflowVersion {
-            version
-            workflow {
-              name
-            }
-          }
-          entityInputs {
-            edges {
-              node {
-                inputEntityId
-                entityType
-              }
-            }
-          }
-        }
-      }`;
-
     assertEqualsNoWhitespace(
-      convertWorkflowRunsQuery(query),
+      convertWorkflowRunsQuery(getExampleQuery("workflow-runs-query-fe")),
       `query ($where: WorkflowRunWhereClause, $orderBy: [WorkflowRunOrderByClause!]) {
         workflowRuns(where: $where, orderBy: $orderBy) {
           id

--- a/tests/utils/StringUtils.ts
+++ b/tests/utils/StringUtils.ts
@@ -1,6 +1,6 @@
 /** Compares 2 strings while ignoring differing length whitespace/tab/newline sequences. */
 export function assertEqualsNoWhitespace(str1: string, str2: string): void {
-  expect(str1.replace(/\s\s+/g, " ").trim()).toBe(
-    str2.replace(/\s\s+/g, " ").trim(),
+  expect(str1.replace(/\s+/g, " ").trim()).toBe(
+    str2.replace(/\s+/g, " ").trim(),
   );
 }

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -71,7 +71,24 @@ export const convertWorkflowRunsQuery = (query: string): string => {
 };
 
 export const convertSequencingReadsQuery = (query: string): string => {
-  let nextGenQuery = query
+  // Remove fed prefix.
+  query = query.replaceAll("fedSequencingReads", "sequencingReads");
+
+  // Only querying ID.
+  if (/{\s*id\s*}/.test(query)) {
+    return (
+      query
+        // Replace Fed variables.
+        .replace(
+          /query [\s\S]*?{/,
+          `query ($where: SequencingReadWhereClause) {`,
+        )
+        // Replace Fed arguments.
+        .replace("input: $input", "where: $where")
+    );
+  }
+
+  query = query
     // Replace Fed variables.
     .replace(
       /query [\s\S]*?{/,
@@ -80,8 +97,6 @@ export const convertSequencingReadsQuery = (query: string): string => {
               $limitOffset: LimitOffsetClause, 
               $producingRunIds: [UUID!]) {`,
     )
-    // Remove fed prefix.
-    .replace("fedSequencingReads", "sequencingReads")
     // Replace Fed arguments.
     .replace(
       "input: $input",
@@ -104,8 +119,8 @@ export const convertSequencingReadsQuery = (query: string): string => {
     "ownerUserName",
     /collection {[\s\S]*?}/,
   ]) {
-    nextGenQuery = nextGenQuery.replace(unsupportedField, "");
+    query = query.replace(unsupportedField, "");
   }
 
-  return nextGenQuery;
+  return query;
 };


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

I was using the wrong IDs to filter `ConsensusGenome`s, therefore wasn't getting any back.

Also add support for query that only fetches `id` (will be used for filters).

Also fix test util assert function that wasn't properly handling single whitespace characters.

## Tests

Should be able to see `ConsensusGenome` fields in samples table in NextGen.
