### PR TITLE
fix: Filter out WorkflowRuns with null sequencing_read inputEntityIds

### DIFF
--- a/tests/WorkflowRunsQuery.test.ts
+++ b/tests/WorkflowRunsQuery.test.ts
@@ -156,7 +156,10 @@ describe("workflowRuns query:", () => {
               name
             }
           }
-          entityInputs(where: { entityType: { _eq: "sequencing_read" } }) {
+          entityInputs(where: { 
+            entityType: { _eq: "sequencing_read" },
+            inputEntityId: { _is_null: false } 
+          }) {
             edges {
               node {
                 inputEntityId

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -65,7 +65,8 @@ export const convertWorkflowRunsQuery = (query: string): string => {
       // Add entityInputs filter (Mesh can't expose nested argument types?).
       .replace(
         "entityInputs",
-        'entityInputs(where: { entityType: { _eq: "sequencing_read" } })',
+        `entityInputs(where: 
+          { entityType: { _eq: "sequencing_read" }, inputEntityId: { _is_null: false } })`,
       )
   );
 };


### PR DESCRIPTION
# Pull Request

Apparently `inputEntityId` can be `null`.

## Tests

Samples view for NextGen should now display correct staging migrated data.
