### PR TITLE
fix: Add schema for fedWorkflowRuns for filtering out WorkflowRuns that don't have the correct input entity

### DIFF
--- a/json-schemas/workflowRunsRequest.json
+++ b/json-schemas/workflowRunsRequest.json
@@ -142,6 +142,27 @@
                         }
                     }
                 },
+                "entityInputs": {
+                    "type": "object",
+                    "properties": {
+                        "entityType": {
+                            "type": "object",
+                            "properties": {
+                                "_eq": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "inputEntityId": {
+                            "type": "object",
+                            "properties": {
+                                "_is_null": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
                 "workflowVersion": {
                     "type": "object",
                     "properties": {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -4156,6 +4156,7 @@ input queryInput_fedWorkflowRuns_input_todoRemove_Input {
 input queryInput_fedWorkflowRuns_input_where_Input {
   collectionId: queryInput_fedWorkflowRuns_input_where_collectionId_Input
   deprecatedById: queryInput_fedWorkflowRuns_input_where_deprecatedById_Input
+  entityInputs: queryInput_fedWorkflowRuns_input_where_entityInputs_Input
   id: queryInput_fedWorkflowRuns_input_where_id_Input
   ownerUserId: queryInput_fedWorkflowRuns_input_where_ownerUserId_Input
   startedAt: queryInput_fedWorkflowRuns_input_where_startedAt_Input
@@ -4167,6 +4168,19 @@ input queryInput_fedWorkflowRuns_input_where_collectionId_Input {
 }
 
 input queryInput_fedWorkflowRuns_input_where_deprecatedById_Input {
+  _is_null: Boolean
+}
+
+input queryInput_fedWorkflowRuns_input_where_entityInputs_Input {
+  entityType: queryInput_fedWorkflowRuns_input_where_entityInputs_entityType_Input
+  inputEntityId: queryInput_fedWorkflowRuns_input_where_entityInputs_inputEntityId_Input
+}
+
+input queryInput_fedWorkflowRuns_input_where_entityInputs_entityType_Input {
+  _eq: String
+}
+
+input queryInput_fedWorkflowRuns_input_where_entityInputs_inputEntityId_Input {
   _is_null: Boolean
 }
 


### PR DESCRIPTION
# Pull Request

We can only have `WorkflowRun`s with `"sequencing_read"` `entityType`s and non-null `inputEntityId`s.

## Tests

Field not used yet.