### PR TITLE
fix: Ziplink return from NextGen

### DIFF
--- a/resolvers.ts
+++ b/resolvers.ts
@@ -1333,13 +1333,13 @@ export const resolvers: Resolvers = {
           serviceType: "workflows",
           customQuery,
         });
+        console.log("ret - ZipLink", JSON.stringify(ret));
         if (
-          ret.data?.consensusGenomes[0]?.intermediateOutputs[0]?.downloadLink
+          ret.data?.consensusGenomes[0]?.intermediateOutputs?.downloadLink
             ?.url
         ) {
           return {
-            url: ret.data.consensusGenomes[0].intermediateOutputs[0]
-              .downloadLink.url,
+            url: ret.data.consensusGenomes[0].intermediateOutputs.downloadLink.url,
           };
         } else {
           return {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9382](https://czi-tech.atlassian.net/browse/CZID-9382)

## Description

The return path for Ziplink was not correct. 

## Tests

Should be able to download a link from a Consensus Genome with some information on it on Staging with the Read From Next Gen Flag on. 


[CZID-9382]: https://czi-tech.atlassian.net/browse/CZID-9382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ