### PR TITLE
fix: convert and use workflowRunIdsStrings if passed in

### DIFF
--- a/resolvers.ts
+++ b/resolvers.ts
@@ -1376,8 +1376,10 @@ export const resolvers: Resolvers = {
       if (!args?.input) {
         throw new Error("No input provided");
       }
-      const { downloadType, workflow, downloadFormat, workflowRunIds } =
+      const { downloadType, workflow, downloadFormat, workflowRunIds, workflowRunIdsStrings } =
         args?.input;
+
+      const workflowRunIdsNumbers = workflowRunIdsStrings?.map(id => id && parseInt(id));
       const body = {
         download_type: downloadType,
         workflow: workflow,
@@ -1386,13 +1388,13 @@ export const resolvers: Resolvers = {
             value: downloadFormat,
           },
           sample_ids: {
-            value: workflowRunIds,
+            value: workflowRunIdsNumbers ?? workflowRunIds,
           },
           workflow: {
             value: workflow,
           },
         },
-        workflow_run_ids: workflowRunIds,
+        workflow_run_ids: workflowRunIdsNumbers ?? workflowRunIds,
       };
       const res = await postWithCSRF({
         url: `/bulk_downloads`,


### PR DESCRIPTION
# Pull Request

## JIRA Ticket
none

## Description
We added an optional workflowRunIdsStrings param, but it wasn't being used. 

