### PR TITLE
feat: Add support for filtering IDs of SequencingReads

### DIFF
--- a/json-schemas/sequencingReadsRequest.json
+++ b/json-schemas/sequencingReadsRequest.json
@@ -31,6 +31,97 @@
                             }
                         }
                     }
+                },
+                "collectionId": {
+                    "type": "object",
+                    "properties": {
+                        "_in": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
+                "sample": {
+                    "type": "object",
+                    "properties": {
+                        "collectionLocation": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "hostOrganism": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "sampleType": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "taxon": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "consensusGenomes": {
+                    "type": "object",
+                    "properties": {
+                        "taxon": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "object",
+                                    "properties": {
+                                        "_in": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -855,14 +855,14 @@ export const resolvers: Resolvers = {
                       locationV2: input.where.sample.collectionLocation?._in,
                       host: input.where.sample.hostOrganism?.name?._in,
                       tissue: input.where.sample.sampleType?._in,
-                      limit: TEN_MILLION,
+                      limit: 0,
                       offset: 0,
-                      listAllIds: false,
+                      listAllIds: true,
                     }),
                   args,
                   context,
                 })
-              ).samples.map(sample => sample.id),
+              ).all_samples_ids,
             );
             sequencingReads = sequencingReads.filter(sequencingRead =>
               filteredSampleIds.has(sequencingRead.sample.railsSampleId),

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -952,26 +952,17 @@ export const resolvers: Resolvers = {
         return nextGenSequencingReads;
       }
 
-      // The comments in the formatUrlParams() call correspond to the line in the current
-      // codebase's callstack where the params are set, so help ensure we're not missing anything.
+      // RAILS:
       const { all_workflow_run_ids, workflow_runs } = await get({
         url:
           "/workflow_runs.json" +
           formatUrlParams({
-            // index.ts
-            // const getWorkflowRuns = ({
             mode: "with_sample_info",
-            //  - DiscoveryDataLayer.ts
-            //    await this._collection.fetchDataCallback({
             domain: input.todoRemove?.domain,
-            //  -- DiscoveryView.tsx
-            //     ...this.getConditions(workflow)
             projectId: input.todoRemove?.projectId,
             search: input.todoRemove?.search,
             orderBy: input.todoRemove?.orderBy,
             orderDir: input.todoRemove?.orderDir,
-            //  --- DiscoveryView.tsx
-            //      filters: {
             host: input.todoRemove?.host,
             locationV2: input.todoRemove?.locationV2,
             taxon: input.todoRemove?.taxons,
@@ -980,8 +971,6 @@ export const resolvers: Resolvers = {
             tissue: input.todoRemove?.tissue,
             visibility: input.todoRemove?.visibility,
             workflow: input.todoRemove?.workflow,
-            //  - DiscoveryDataLayer.ts
-            //    await this._collection.fetchDataCallback({
             limit: queryingIdsOnly
               ? 0
               : input.limit ?? input.limitOffset?.limit, // TODO: Just use limitOffset.
@@ -994,7 +983,7 @@ export const resolvers: Resolvers = {
         context,
       });
       if (queryingIdsOnly) {
-        return all_workflow_run_ids;
+        return all_workflow_run_ids.map(id => ({ id }));
       }
       if (!workflow_runs?.length) {
         return [];

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -1,5 +1,9 @@
 import { ExecuteMeshFn } from "@graphql-mesh/runtime";
-import { getMeshInstance } from "./utils/MeshInstance";
+import {
+  MeshExecuteTestFunction,
+  getMeshExecute,
+  getMeshInstance,
+} from "./utils/MeshInstance";
 import * as httpUtils from "../utils/httpUtils";
 import { getExampleQuery } from "./utils/ExampleQueryFiles";
 import { assertEqualsNoWhitespace } from "./utils/StringUtils";
@@ -20,14 +24,13 @@ beforeEach(() => {
 const query = getExampleQuery("sequencing-reads-query");
 
 describe("sequencingReads query:", () => {
-  let execute: ExecuteMeshFn;
+  let execute: MeshExecuteTestFunction;
 
   beforeEach(async () => {
     (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(() =>
       Promise.resolve(false),
     );
-    const mesh$ = await getMeshInstance();
-    ({ execute } = mesh$);
+    execute = await getMeshExecute();
   });
 
   it("Returns empty list", async () => {
@@ -35,6 +38,7 @@ describe("sequencingReads query:", () => {
       workflow_runs: [],
     }));
     const response = await execute(query, {});
+    console.log(JSON.stringify(response));
 
     expect(httpUtils.get).toHaveBeenCalledWith({
       url: "/workflow_runs.json?&mode=with_sample_info&search=abc&limit=50&offset=100&listAllIds=false",
@@ -489,8 +493,7 @@ describe("sequencingReads query:", () => {
       }),
     );
 
-    const sequencingReads = (await execute(query, {}, { params: { query } }))
-      .data.fedSequencingReads;
+    const sequencingReads = (await execute(query, {})).data.fedSequencingReads;
 
     expect(sequencingReads).toMatchObject([
       expect.objectContaining({
@@ -606,11 +609,7 @@ describe("sequencingReads query:", () => {
     );
 
     const sequencingReads = (
-      await execute(
-        query,
-        { input: { where: { sample: {} } } },
-        { params: { query } },
-      )
+      await execute(query, { input: { where: { sample: {} } } })
     ).data.fedSequencingReads;
 
     expect(sequencingReads).toMatchObject([
@@ -621,6 +620,24 @@ describe("sequencingReads query:", () => {
         id: "def",
       },
     ]);
+  });
+
+  it("Fetches all IDs only from Rails if NextGen off", async () => {
+    const query = getExampleQuery("sequencing-reads-query-id-fe");
+    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(() =>
+      Promise.resolve(false),
+    );
+    (httpUtils.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        all_workflow_run_ids: [123, 456],
+      }),
+    );
+
+    const sequencingReads = (await execute(query, { input: {} })).data
+      .fedSequencingReads;
+
+    expect(httpUtils.fetchFromNextGen as jest.Mock).not.toHaveBeenCalled();
+    expect(sequencingReads).toMatchObject([{ id: 123 }, { id: 456 }]);
   });
 
   it("Does not call Rails if ID query has no sample filter", async () => {
@@ -655,9 +672,8 @@ describe("sequencingReads query:", () => {
       }),
     );
 
-    const sequencingReads = (
-      await execute(query, { input: {} }, { params: { query } })
-    ).data.fedSequencingReads;
+    const sequencingReads = (await execute(query, { input: {} })).data
+      .fedSequencingReads;
 
     expect(httpUtils.getFromRails as jest.Mock).not.toHaveBeenCalled();
     expect(sequencingReads).toMatchObject([
@@ -685,8 +701,7 @@ describe("sequencingReads query:", () => {
       }),
     );
 
-    const sequencingReads = (await execute(query, {}, { params: { query } }))
-      .data.fedSequencingReads;
+    const sequencingReads = (await execute(query, {})).data.fedSequencingReads;
 
     expect(sequencingReads).toEqual([]);
     expect(httpUtils.getFromRails as jest.Mock).not.toHaveBeenCalled();
@@ -710,11 +725,7 @@ describe("sequencingReads query:", () => {
     );
 
     const sequencingReads = (
-      await execute(
-        query,
-        { input: { where: { id: { _in: ["abc"] } } } },
-        { params: { query } },
-      )
+      await execute(query, { input: { where: { id: { _in: ["abc"] } } } })
     ).data.fedSequencingReads;
 
     expect(sequencingReads).toEqual([{ id: "abc" }]);

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -402,6 +402,9 @@ describe("sequencingReads query:", () => {
       `query ($where: SequencingReadWhereClause) {
         sequencingReads(where: $where) {
           id
+          sample {
+            railsSampleId
+          }
         }
       }`,
     );

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -4044,10 +4044,60 @@ input queryInput_fedSequencingReads_input_todoRemove_Input {
 }
 
 input queryInput_fedSequencingReads_input_where_Input {
+  collectionId: queryInput_fedSequencingReads_input_where_collectionId_Input
+  consensusGenomes: queryInput_fedSequencingReads_input_where_consensusGenomes_Input
   id: queryInput_fedSequencingReads_input_where_id_Input
+  sample: queryInput_fedSequencingReads_input_where_sample_Input
+  taxon: queryInput_fedSequencingReads_input_where_taxon_Input
+}
+
+input queryInput_fedSequencingReads_input_where_collectionId_Input {
+  _in: [Int]
+}
+
+input queryInput_fedSequencingReads_input_where_consensusGenomes_Input {
+  taxon: queryInput_fedSequencingReads_input_where_consensusGenomes_taxon_Input
+}
+
+input queryInput_fedSequencingReads_input_where_consensusGenomes_taxon_Input {
+  name: queryInput_fedSequencingReads_input_where_consensusGenomes_taxon_name_Input
+}
+
+input queryInput_fedSequencingReads_input_where_consensusGenomes_taxon_name_Input {
+  _in: [String]
 }
 
 input queryInput_fedSequencingReads_input_where_id_Input {
+  _in: [String]
+}
+
+input queryInput_fedSequencingReads_input_where_sample_Input {
+  collectionLocation: queryInput_fedSequencingReads_input_where_sample_collectionLocation_Input
+  hostOrganism: queryInput_fedSequencingReads_input_where_sample_hostOrganism_Input
+  sampleType: queryInput_fedSequencingReads_input_where_sample_sampleType_Input
+}
+
+input queryInput_fedSequencingReads_input_where_sample_collectionLocation_Input {
+  _in: [String]
+}
+
+input queryInput_fedSequencingReads_input_where_sample_hostOrganism_Input {
+  name: queryInput_fedSequencingReads_input_where_sample_hostOrganism_name_Input
+}
+
+input queryInput_fedSequencingReads_input_where_sample_hostOrganism_name_Input {
+  _in: [String]
+}
+
+input queryInput_fedSequencingReads_input_where_sample_sampleType_Input {
+  _in: [String]
+}
+
+input queryInput_fedSequencingReads_input_where_taxon_Input {
+  name: queryInput_fedSequencingReads_input_where_taxon_name_Input
+}
+
+input queryInput_fedSequencingReads_input_where_taxon_name_Input {
   _in: [String]
 }
 

--- a/tests/utils/MeshInstance.ts
+++ b/tests/utils/MeshInstance.ts
@@ -1,9 +1,19 @@
-import { getMesh, MeshInstance } from '@graphql-mesh/runtime';
-import { join } from 'path';
+import { getMesh, MeshInstance } from "@graphql-mesh/runtime";
+import { join } from "path";
 import { findAndParseConfig } from "@graphql-mesh/cli";
 
-export const getMeshInstance = async () : Promise<MeshInstance> => {
+export const getMeshInstance = async (): Promise<MeshInstance> => {
   return findAndParseConfig({
     dir: join(__dirname, "../../"),
   }).then(config => getMesh(config));
+};
+
+export type MeshExecuteTestFunction = (
+  query: string,
+  input: any,
+) => Promise<any>;
+
+export const getMeshExecute = async (): Promise<MeshExecuteTestFunction> => {
+  const mesh = await getMeshInstance();
+  return (query, input) => mesh.execute(query, input, { params: { query } });
 };

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -86,6 +86,16 @@ export const convertSequencingReadsQuery = (query: string): string => {
         )
         // Replace Fed arguments.
         .replace("input: $input", "where: $where")
+        // Add railsSampleId field.
+        .replace(
+          /{\s*id\s*}/,
+          `{
+             id
+             sample {
+               railsSampleId
+             }
+           }`,
+        )
     );
   }
 


### PR DESCRIPTION
# Pull Request

This sends taxon filters to NextGen and sample metadata based filters to Rails.

The calls are synchronous so I can filter down the Rails call to only the samples we care about (and not do full table joins).

The NextGen query is modified (FE only needs `id`) to include `sample { railsSampleId }` so we can do the join with Rails.

## Tests

Functionality not used yet.
