### PR TITLE
fix: Construct nextgen aggregates query appropriately

### DIFF
--- a/resolvers.ts
+++ b/resolvers.ts
@@ -1276,22 +1276,22 @@ export const resolvers: Resolvers = {
 
       if (nextGenEnabled) {
         const customQuery = `
-            query nextGenWorkflowsAggregate {
-              workflowRunsAggregate(where: $where) {
-                aggregate {
-                  groupBy {
-                    collectionId
-                    workflowVersion {
-                      workflow {
-                        name
-                      }
+          query nextGenWorkflowsAggregate($where: WorkflowRunWhereClause) {
+            workflowRunsAggregate(where: $where) {
+              aggregate {
+                groupBy {
+                  collectionId
+                  workflowVersion {
+                    workflow {
+                      name
                     }
                   }
-                  count
                 }
+                count
               }
             }
-          `;
+          }
+        `;
         const consensusGenomesAggregateResponse = await fetchFromNextGen({
           args,
           context,


### PR DESCRIPTION
# Pull Request

## Description

Fixes the `where` clause in the next gen workflow runs aggregate query

## Notes


## Tests

Don't have any workflows data locally but didn't see errors in the logs of the workflows service when I ran the query from the frontend.
