### PR TITLE
fix: fedConsensusGenomes: Make name available in rails

### DIFF
--- a/resolvers.ts
+++ b/resolvers.ts
@@ -257,6 +257,7 @@ export const resolvers: Resolvers = {
             taxon: {
               id: taxon_id?.toString(),
               commonName: taxon_name,
+              name: taxon_name,
             },
           },
         ];


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

no ticket

## Description

Make it possible for Taxon Name to be read on Sample report

## Tests

Should be able to view Taxon name on CG Sample report with this sister PR: https://github.com/chanzuckerberg/czid-web-private/pull/4396


