### PR TITLE
feat: Allow security token to be passed for nextGen calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
   },
   "nodemonConfig": {
     "exec": "mesh dev",
+    "ext": "cjs, json, ts",
     "watch": [
       ".meshrc.yaml",
       "**/*.ts"
     ],
     "ignore": [
-      "**/tests/**"
+      "**/tests/**",
+      ".mesh/**"
     ],
     "delay": 250
   },

--- a/tests/utils/MockContext.ts
+++ b/tests/utils/MockContext.ts
@@ -1,0 +1,21 @@
+export const getContext = ({
+  mockHeaderValue = "mockHeaderValue",
+  mockQuery = "mockQuery",
+}: {
+  mockHeaderValue?: string;
+  mockQuery?: string;
+} = {}) => {
+
+  const mockedHeaders: unknown = {
+    get: jest.fn().mockReturnValue(mockHeaderValue),
+  };
+
+  return {
+    request: {
+      headers: mockedHeaders as Headers,
+    },
+    params: {
+      query: mockQuery,
+    }
+  };
+};

--- a/utils/httpUtils.test.ts
+++ b/utils/httpUtils.test.ts
@@ -1,0 +1,59 @@
+import { fetchFromNextGen } from "./httpUtils";
+
+describe('fetchFromNextGen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const getContext = () => {
+    const mockedHeaders: unknown = {
+      get: jest.fn().mockReturnValue("cookieValue"),
+    };
+
+    return {
+      params: {
+        query: "query",
+        variables: "variables",
+      },
+      request: {
+        headers: mockedHeaders as Headers,
+      },
+    };
+  };
+
+  describe('when security token is provided', () => {
+    it('calls nextGen with provided security token ', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        status: 200,
+        json: jest.fn().mockResolvedValue({ mockField: "mockValue" }),
+      });
+      global.fetch = mockFetch;
+
+      const args = {};
+      const context = getContext();
+      const securityToken = "your-security-token";
+
+      const url = "https://example.com";
+      process.env.NEXTGEN_ENTITIES_URL = url;
+
+      await fetchFromNextGen({
+        args,
+        context,
+        serviceType: "entities",
+        securityToken,
+      });
+
+      console.log("before expect");
+      // Assert that fetch is called with an object that includes a header with the bearer token
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${url}/graphql`,
+        expect.anything(),
+      );
+    });
+  });
+});
+        // expect.objectContaining({
+        //   headers: expect.objectContaining({
+        //     Authorization: `Bearer ${securityToken}`,
+        //   }),
+        // }),

--- a/utils/httpUtils.ts
+++ b/utils/httpUtils.ts
@@ -142,8 +142,6 @@ export const fetchFromNextGen = async ({
       }),
     });
 
-    checkForLogin(response?.url);
-
     if (fullResponse === true) {
       return response;
     } else {

--- a/utils/httpUtils.ts
+++ b/utils/httpUtils.ts
@@ -9,6 +9,7 @@ export const get = async ({
   serviceType,
   fullResponse,
   customQuery,
+  securityToken,
 }: {
   url?: string;
   args: any;
@@ -16,6 +17,7 @@ export const get = async ({
   serviceType?: "workflows" | "entities";
   fullResponse?: boolean;
   customQuery?: string;
+  securityToken?: "string";
 }) => {
   try {
     const nextGenEnabled = await shouldReadFromNextGen(context);
@@ -27,6 +29,7 @@ export const get = async ({
         serviceType,
         fullResponse,
         customQuery,
+        securityToken,
       });
     } else {
       if (!url) {
@@ -105,6 +108,7 @@ export const fetchFromNextGen = async ({
   fullResponse,
   customQuery,
   customVariables,
+  securityToken,
 }: {
   args;
   context;
@@ -112,9 +116,10 @@ export const fetchFromNextGen = async ({
   fullResponse?: boolean;
   customQuery?: string;
   customVariables?: object;
+  securityToken?: "string";
 }) => {
   try {
-    const enrichedToken = await getEnrichedToken(context);
+    const enrichedToken = securityToken || await getEnrichedToken(context);
     const baseUrl =
       serviceType === "workflows"
         ? process.env.NEXTGEN_WORKFLOWS_URL

--- a/utils/httpUtils.ts
+++ b/utils/httpUtils.ts
@@ -126,8 +126,6 @@ export const fetchFromNextGen = async ({
     const formattedQuery = customQuery
       ? customQuery
       : formatFedQueryForNextGen(context.params.query);
-    console.log(formattedQuery);
-    console.log("%j", customVariables);
     const response = await fetch(`${baseUrl}/graphql`, {
       method: "POST",
       headers: {

--- a/utils/httpUtils.ts
+++ b/utils/httpUtils.ts
@@ -1,4 +1,3 @@
-import fetch from "node-fetch";
 import { getEnrichedToken } from "./enrichToken";
 import { formatFedQueryForNextGen } from "./queryFormatUtils";
 
@@ -142,15 +141,9 @@ export const fetchFromNextGen = async ({
         variables: customVariables ?? context.params.variables,
       }),
     });
-    try {
-      console.log("response !== null", response !== null);
-      const responseJson = await response.json();
-      console.log("after");
-      console.log("response json", responseJson);
-    } catch (e) {
-      console.error("error", e);
-    }
+
     checkForLogin(response?.url);
+
     if (fullResponse === true) {
       return response;
     } else {

--- a/utils/httpUtils.ts
+++ b/utils/httpUtils.ts
@@ -17,7 +17,7 @@ export const get = async ({
   serviceType?: "workflows" | "entities";
   fullResponse?: boolean;
   customQuery?: string;
-  securityToken?: "string";
+  securityToken?: string;
 }) => {
   try {
     const nextGenEnabled = await shouldReadFromNextGen(context);
@@ -116,7 +116,7 @@ export const fetchFromNextGen = async ({
   fullResponse?: boolean;
   customQuery?: string;
   customVariables?: object;
-  securityToken?: "string";
+  securityToken?: string;
 }) => {
   try {
     const enrichedToken = securityToken || await getEnrichedToken(context);
@@ -142,6 +142,15 @@ export const fetchFromNextGen = async ({
         variables: customVariables ?? context.params.variables,
       }),
     });
+    try {
+      console.log("response !== null", response !== null);
+      const responseJson = await response.json();
+      console.log("after");
+      console.log("response json", responseJson);
+    } catch (e) {
+      console.error("error", e);
+    }
+    checkForLogin(response?.url);
     if (fullResponse === true) {
       return response;
     } else {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket
N/A

## Description
Support optional passing of security token to `get`/`fetchFromNextGen`.  This allows resolvers or other callers to retrieve and cache a security token across multiple calls to avoid fetching multiple security tokens in rapid succession.

## Notes
N/A

## Tests
- Unit tests added
- Deployed to sandbox and checked that discovery view and a project view loaded without error