### PR TITLE
fix: BulkDownloadModal Validation - Reformat query

### DIFF
--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -60,7 +60,7 @@ export const convertValidateConsensusGenomeQuery = (query: string): string => {
       // Remove fed prefix.
       .replace("fedWorkflowRuns", "workflowRuns")
       // Replace Fed arguments.
-      .replace(/input:.*\n/, "where: $where\n")      
+      .replace(/input:.*\n/, "where: $where){\n")      
   )
 };
 

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -55,7 +55,7 @@ export const convertValidateConsensusGenomeQuery = (query: string): string => {
       // Replace Fed variables.
       .replace(
         /query [\s\S]*?{/,
-        "query ($where: ConsensusGenomeWhereClause) {",
+        "query ($where: WorkflowRunWhereClause) {",
       )
       // Remove fed prefix.
       .replace("fedWorkflowRuns", "workflowRuns")

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -55,7 +55,7 @@ export const convertValidateConsensusGenomeQuery = (query: string): string => {
       // Remove fed prefix.
       .replace("fedWorkflowRuns", "workflowRuns")
       // Replace Fed arguments.
-      .replace(/input:.*\n/, "where: $where")
+      .replace(/input:.*\n/, "where: $where){\n")
       
   )
 };

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -60,7 +60,7 @@ export const convertValidateConsensusGenomeQuery = (query: string): string => {
       // Remove fed prefix.
       .replace("fedWorkflowRuns", "workflowRuns")
       // Replace Fed arguments.
-      .replace(/input:.*\n/, "where: $where){\n")      
+      .replace(/input:[\s\S]*?\)/, "where: $where)")      
   )
 };
 

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -52,11 +52,15 @@ export const formatFedQueryForNextGen = (query: string): string => {
 export const convertValidateConsensusGenomeQuery = (query: string): string => {
   return (
     query
+      // Replace Fed variables.
+      .replace(
+        /query [\s\S]*?{/,
+        "query ($where: ConsensusGenomeWhereClause) {",
+      )
       // Remove fed prefix.
       .replace("fedWorkflowRuns", "workflowRuns")
       // Replace Fed arguments.
-      .replace(/input:.*\n/, "where: $where){\n")
-      
+      .replace(/input:.*\n/, "where: $where\n")      
   )
 };
 


### PR DESCRIPTION
# Pull Request

## JIRA Ticket
none

## Description
Updating syntax

## Notes


## Tests
Works in sandbox
When on the CG SamplesView page, select some samples and open the BulkDownloadModal.  The modal should open without giving an error.
