### PR TITLE
chore: Add sampleIds & workflowRunIds on fedConsensusGenome for API testing

### DIFF
--- a/json-schemas/consensusGenomesRequest.json
+++ b/json-schemas/consensusGenomesRequest.json
@@ -133,6 +133,12 @@
                 },
                 "orderDir": {
                     "type": "string"
+                },
+                "sampleIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         }

--- a/json-schemas/consensusGenomesRequest.json
+++ b/json-schemas/consensusGenomesRequest.json
@@ -139,6 +139,12 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "workflowRunIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         }

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -289,14 +289,16 @@ export const resolvers: Resolvers = {
             //      filters: {
             host: input?.todoRemove?.host,
             locationV2: input?.todoRemove?.locationV2,
-            sampleIds: input?.todoRemove?.sampleIds,
             taxon: input?.todoRemove?.taxons,
             taxaLevels: input?.todoRemove?.taxaLevels,
             time: input?.todoRemove?.time,
             tissue: input?.todoRemove?.tissue,
             visibility: input?.todoRemove?.visibility,
             workflow: input?.todoRemove?.workflow,
+            // sampleIds and workflowRunIds are only used for API testing, not in the app.
             workflowRunIds: input?.todoRemove?.workflowRunIds,
+            sampleIds: input?.todoRemove?.sampleIds,
+
             //  - DiscoveryDataLayer.ts
             //    await this._collection.fetchDataCallback({
             limit: input?.limit,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -296,6 +296,7 @@ export const resolvers: Resolvers = {
             tissue: input?.todoRemove?.tissue,
             visibility: input?.todoRemove?.visibility,
             workflow: input?.todoRemove?.workflow,
+            workflowRunIds: input?.todoRemove?.workflowRunIds,
             //  - DiscoveryDataLayer.ts
             //    await this._collection.fetchDataCallback({
             limit: input?.limit,

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -289,6 +289,7 @@ export const resolvers: Resolvers = {
             //      filters: {
             host: input?.todoRemove?.host,
             locationV2: input?.todoRemove?.locationV2,
+            sampleIds: input?.todoRemove?.sampleIds,
             taxon: input?.todoRemove?.taxons,
             taxaLevels: input?.todoRemove?.taxaLevels,
             time: input?.todoRemove?.time,

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -3815,6 +3815,7 @@ input queryInput_fedConsensusGenomes_input_todoRemove_Input {
   orderBy: String
   orderDir: String
   projectId: String
+  sampleIds: [Int]
   search: String
   taxaLevels: [String]
   taxons: [Int]
@@ -3822,6 +3823,7 @@ input queryInput_fedConsensusGenomes_input_todoRemove_Input {
   tissue: [String]
   visibility: String
   workflow: String
+  workflowRunIds: [Int]
 }
 
 input queryInput_fedConsensusGenomes_input_where_Input {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket
Adds `sampleIds` to todoRemove so we can filter consensusGenomes by sampleIds 

## Tests
Needed for API testing