### PR TITLE
fix: Use workflowRunIdsNumbers when available

### DIFF
--- a/resolvers.ts
+++ b/resolvers.ts
@@ -184,6 +184,7 @@ export const resolvers: Resolvers = {
       const workflowRunIdsNumbers = workflowRunIdsStrings?.map(
         id => id && parseInt(id),
       );
+
       const body = {
         download_type: downloadType,
         workflow: workflow,
@@ -198,7 +199,9 @@ export const resolvers: Resolvers = {
             value: workflow,
           },
         },
-        workflow_run_ids: workflowRunIds,
+        workflow_run_ids: workflowRunIdsNumbers
+          ? workflowRunIdsNumbers
+          : workflowRunIds,
       };
       const res = await postWithCSRF({
         url: `/bulk_downloads/consensus_genome_overview_data`,


### PR DESCRIPTION
# Pull Request

## JIRA Ticket
none

## Description
Fixes csv download through the BulkDownloadModal when the NextGen flag is off

## Notes
Fixes this:
<img width="608" alt="Screenshot 2024-03-20 at 4 18 38 PM" src="https://github.com/chanzuckerberg/czid-graphql-federation-server/assets/109251328/72a0d33f-c705-43cc-8c2d-a38099b257c9">


## Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*
