### PR TITLE
feat: Add sorting by consensusGenomes field functionality in Fed

### DIFF
--- a/json-schemas/consensusGenomesRequest.json
+++ b/json-schemas/consensusGenomesRequest.json
@@ -27,48 +27,51 @@
             }
         },
         "orderBy": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": "object",
-                    "properties": {
-                        "accessionId": {
-                            "type": "string"
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "accession": {
+                        "type": "object",
+                        "properties": {
+                            "accessionId": {
+                                "type": "string"
+                            }
                         }
-                    }
-                },
-                "metrics": {
-                    "type": "object",
-                    "properties": {
-                        "coverageDepth": {
-                            "type": "string"
-                        },
-                        "totalReads": {
-                            "type": "string"
-                        },
-                        "gcPercent": {
-                            "type": "string"
-                        },
-                        "refSnps": {
-                            "type": "string"
-                        },
-                        "percentIdentity": {
-                            "type": "string"
-                        },
-                        "nActg": {
-                            "type": "string"
-                        },
-                        "percentGenomeCalled": {
-                            "type": "string"
-                        },
-                        "nMissing": {
-                            "type": "string"
-                        },
-                        "nAmbiguous": {
-                            "type": "string"
-                        },
-                        "referenceGenomeLength": {
-                            "type": "string"
+                    },
+                    "metrics": {
+                        "type": "object",
+                        "properties": {
+                            "coverageDepth": {
+                                "type": "string"
+                            },
+                            "totalReads": {
+                                "type": "string"
+                            },
+                            "gcPercent": {
+                                "type": "string"
+                            },
+                            "refSnps": {
+                                "type": "string"
+                            },
+                            "percentIdentity": {
+                                "type": "string"
+                            },
+                            "nActg": {
+                                "type": "string"
+                            },
+                            "percentGenomeCalled": {
+                                "type": "string"
+                            },
+                            "nMissing": {
+                                "type": "string"
+                            },
+                            "nAmbiguous": {
+                                "type": "string"
+                            },
+                            "referenceGenomeLength": {
+                                "type": "string"
+                            }
                         }
                     }
                 }

--- a/json-schemas/consensusGenomesRequest.json
+++ b/json-schemas/consensusGenomesRequest.json
@@ -10,6 +10,17 @@
         "where": {
             "type": "object",
             "properties": {
+                "collectionId": {
+                    "type": "object",
+                    "properties": {
+                        "_in": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
                 "producingRunId": {
                     "type": "object",
                     "properties": {

--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -92,6 +92,9 @@
             "sequencingRead": {
                 "type": "object",
                 "properties": {
+                    "id": {
+                        "type": "string"
+                    },
                     "nucleicAcid": {
                         "type": "string"
                     },
@@ -193,7 +196,7 @@
                         "required": ["name", "collectionLocation", "sampleType", "metadatas"]
                     }
                 },
-                "required": ["nucleicAcid", "technology"]
+                "required": ["id", "nucleicAcid", "technology"]
             },
             "referenceGenome": {
                 "type": "object",

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -68,18 +68,17 @@ export const resolvers: Resolvers = {
     fedBulkDownloads: fedBulkDowloadsResolver,
     BulkDownloadCGOverview: BulkDownloadsCGOverviewResolver,
     fedConsensusGenomes: async (root, args, context) => {
-      /* --------------------- Next Gen ------------------------- */
-      const nextGenEnabled = await shouldReadFromNextGen(context);
-      if (nextGenEnabled) {
-        const ret = await get({ args, context, serviceType: "entities" });
-        return ret.data.consensusGenomes;
-      }
-      /* --------------------- Rails ------------------------- */
-      console.log(args.input)
       const input = args.input;
+      const nextGenEnabled = await shouldReadFromNextGen(context);
+
+      // if there is an _eq in the response then it is a call for a single workflow run result
       if (input?.where?.producingRunId?._eq) {
-        // if there is an _eq in the response than it is a call for a single workflow run result
-        // and the rails call will be like this:
+        /* --------------------- Next Gen ------------------------- */
+        if (nextGenEnabled) {
+          const ret = await get({ args, context, serviceType: "entities" });
+          return ret.data.consensusGenomes;
+        }
+        /* --------------------- Rails ----------------------------- */
         const workflowRunId = input?.where?.producingRunId?._eq;
         const data = await get({
           url: `/workflow_runs/${workflowRunId}/results`,
@@ -135,26 +134,48 @@ export const resolvers: Resolvers = {
       }
 
       // DISCOVERY VIEW:
-      // The comments in the formatUrlParams() call correspond to the line in the current
-      // codebase's callstack where the params are set, so help ensure we're not missing anything.
+      if (nextGenEnabled) {
+        return (
+          await fetchFromNextGen({
+            customQuery: convertSequencingReadsQuery(context.params.query),
+            customVariables: {
+              where: {
+                collectionId: input.where?.collectionId,
+                taxon: input.where?.taxon,
+                consensusGenomes: input.where?.consensusGenomes,
+                // Entities Service doesn't support sample host + metadata yet.
+                sample:
+                  input.where?.sample?.name != null
+                    ? {
+                        name: input.where.sample.name,
+                      }
+                    : undefined,
+              },
+              orderBy:
+                input.orderByArray?.[0]?.protocol != null ||
+                input.orderByArray?.[0]?.technology != null ||
+                input.orderByArray?.[0]?.medakaModel != null ||
+                input.orderByArray?.[0]?.sample?.name != null
+                  ? input.orderByArray
+                  : undefined,
+            },
+            serviceType: "entities",
+            args,
+            context,
+          })
+        ).data.consensusGenomes;
+      }
+
       const { workflow_runs } = await get({
         url:
           "/workflow_runs.json" +
           formatUrlParams({
-            // index.ts
-            // const getWorkflowRuns = ({
-            mode: "with_sample_info",
-            //  - DiscoveryDataLayer.ts
-            //    await this._collection.fetchDataCallback({
+            mode: "basic",
             domain: input?.todoRemove?.domain,
-            //  -- DiscoveryView.tsx
-            //     ...this.getConditions(workflow)
             projectId: input?.todoRemove?.projectId,
             search: input?.todoRemove?.search,
             orderBy: input?.todoRemove?.orderBy,
             orderDir: input?.todoRemove?.orderDir,
-            //  --- DiscoveryView.tsx
-            //      filters: {
             host: input?.todoRemove?.host,
             locationV2: input?.todoRemove?.locationV2,
             taxon: input?.todoRemove?.taxons,
@@ -163,14 +184,10 @@ export const resolvers: Resolvers = {
             tissue: input?.todoRemove?.tissue,
             visibility: input?.todoRemove?.visibility,
             workflow: input?.todoRemove?.workflow,
-            // sampleIds and workflowRunIds are only used for API testing, not in the app.
             workflowRunIds: input?.todoRemove?.workflowRunIds,
             sampleIds: input?.todoRemove?.sampleIds,
-
-            //  - DiscoveryDataLayer.ts
-            //    await this._collection.fetchDataCallback({
-            limit: input?.limit,
-            offset: input?.offset,
+            limit: TEN_MILLION,
+            offset: 0,
             listAllIds: false,
           }),
         args,
@@ -180,80 +197,13 @@ export const resolvers: Resolvers = {
         return [];
       }
 
-      return workflow_runs.map((run): query_fedConsensusGenomes_items => {
-        const inputs = run.inputs;
-        const qualityMetrics = run.cached_results?.quality_metrics;
-        const sample = run.sample;
-        const sampleInfo = sample?.info;
-        const sampleMetadata = sample?.metadata;
-
-        const taxon =
-          inputs?.taxon_name != null
-            ? {
-                name: inputs.taxon_name,
-              }
-            : null;
-        const accession =
-          inputs?.accession_id != null && inputs?.accession_name != null
-            ? {
-                accessionId: inputs?.accession_id,
-                accessionName: inputs?.accession_name,
-              }
-            : null;
-        return {
-          producingRunId: run.id?.toString(),
-          taxon,
-          accession,
-          metrics: {
-            coverageDepth: run.cached_results?.coverage_viz?.coverage_depth,
-            totalReads: qualityMetrics?.total_reads,
-            gcPercent: qualityMetrics?.gc_percent,
-            refSnps: qualityMetrics?.ref_snps,
-            percentIdentity: qualityMetrics?.percent_identity,
-            nActg: qualityMetrics?.n_actg,
-            percentGenomeCalled: qualityMetrics?.percent_genome_called,
-            nMissing: qualityMetrics?.n_missing,
-            nAmbiguous: qualityMetrics?.n_ambiguous,
-            referenceGenomeLength: qualityMetrics?.reference_genome_length,
-          },
+      return workflow_runs.map(
+        (run): query_fedConsensusGenomes_items => ({
           sequencingRead: {
-            nucleicAcid: sampleMetadata?.nucleotide_type ?? "",
-            protocol: inputs?.wetlab_protocol,
-            medakaModel: inputs?.medaka_model,
-            technology: inputs?.technology ?? "",
-            taxon,
-            sample: {
-              railsSampleId: sample?.id,
-              name: sampleInfo?.name ?? "",
-              notes: sampleInfo?.sample_notes,
-              uploadError: sampleInfo?.result_status_description,
-              collectionLocation:
-                typeof sampleMetadata?.collection_location_v2 === "string"
-                  ? sampleMetadata.collection_location_v2
-                  : sampleMetadata?.collection_location_v2?.name ?? "",
-              sampleType: sampleMetadata?.sample_type ?? "",
-              waterControl: sampleMetadata?.water_control === "Yes",
-              hostOrganism:
-                sampleInfo?.host_genome_name != null
-                  ? {
-                      name: sampleInfo.host_genome_name,
-                    }
-                  : null,
-              collection: {
-                name: sample?.project_name,
-                public: Boolean(sampleInfo?.public),
-              },
-              ownerUserId: sample?.uploader?.id,
-              // TODO: Make runner come from Workflows stitched with the user service when NextGen
-              // ready.
-              ownerUserName: run.runner?.name ?? sample?.uploader?.name,
-              metadatas: {
-                edges: getMetadataEdges(sampleMetadata),
-              },
-            },
+            id: run.sample.id,
           },
-        };
-      });
+        }),
+      );
     },
     ConsensusGenomeWorkflowResults: async (root, args, context, info) => {
       const { coverage_viz, quality_metrics, taxon_info } = await get({

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -72,8 +72,7 @@ export const resolvers: Resolvers = {
       const nextGenEnabled = await shouldReadFromNextGen(context);
       const input = args.input;
       if (input == null) {
-        console.log("Error: fedConsensusGenomes input was nullish");
-        return [];
+        throw new Error("fedConsensusGenomes input was nullish");
       }
 
       // if there is an _eq in the response then it is a call for a single workflow run result

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -183,7 +183,7 @@ export const resolvers: Resolvers = {
       });
       return workflow_runs.map(run => ({
         sequencingRead: {
-          id: run.sample.id,
+          id: run.sample.info.id.toString(),
         },
       }));
     },

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -84,7 +84,7 @@ export const resolvers: Resolvers = {
           return ret.data.consensusGenomes;
         }
         /* --------------------- Rails ----------------------------- */
-        const workflowRunId = input.where?.producingRunId?._eq;
+        const workflowRunId = input.where.producingRunId._eq;
         const data = await get({
           url: `/workflow_runs/${workflowRunId}/results`,
           args,

--- a/tests/FedConsensusGenomesQuery.test.ts
+++ b/tests/FedConsensusGenomesQuery.test.ts
@@ -21,7 +21,9 @@ describe("fedConsensusGenomes DiscoveryView query:", () => {
   beforeEach(async () => {
     const mesh$ = await getMeshInstance();
     ({ execute } = mesh$);
-    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(() => false);
+    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(
+      () => false,
+    );
   });
 
   it("Returns empty list", async () => {
@@ -30,91 +32,11 @@ describe("fedConsensusGenomes DiscoveryView query:", () => {
     }));
     const response = await execute(query, {});
     expect(httpUtils.get).toHaveBeenCalledWith({
-      url: "/workflow_runs.json?&mode=with_sample_info&search=abc&listAllIds=false",
+      url: "/workflow_runs.json?&mode=basic&search=abc&limit=10000000&offset=0&listAllIds=false",
       args: expect.anything(),
       context: expect.anything(),
     });
     expect(response.data.fedConsensusGenomes).toHaveLength(0);
-  });
-
-  it("Returns nested fields", async () => {
-    (httpUtils.get as jest.Mock).mockImplementation(() => ({
-      workflow_runs: [
-        {
-          id: 123,
-          inputs: {
-            taxon_name: "Taxon1",
-          },
-        },
-        {
-          id: 456,
-          inputs: {
-            taxon_name: "Taxon2",
-          },
-        },
-      ],
-    }));
-
-    const result = await execute(query, {});
-
-    expect(result.data.fedConsensusGenomes).toHaveLength(2);
-    expect(result.data.fedConsensusGenomes[0]).toEqual(
-      expect.objectContaining({
-        producingRunId: "123",
-        taxon: {
-          name: "Taxon1",
-        },
-      }),
-    );
-    expect(result.data.fedConsensusGenomes[1]).toEqual(
-      expect.objectContaining({
-        producingRunId: "456",
-        taxon: {
-          name: "Taxon2",
-        },
-      }),
-    );
-  });
-
-  it("Returns metadata", async () => {
-    (httpUtils.get as jest.Mock).mockImplementation(() => ({
-      workflow_runs: [
-        {
-          sample: {
-            metadata: {
-              key1: "value1",
-              nucleotide_type: "DNA",
-              key2: "value2",
-              key3: "value3",
-            },
-          },
-        },
-      ],
-    }));
-
-    const result = await execute(query, {});
-
-    const metadataFields = result.data.fedConsensusGenomes[0].sequencingRead.sample.metadatas.edges.map(
-      edge => edge.node.fieldName,
-    );
-    expect(metadataFields).toHaveLength(3);
-    expect(metadataFields[0]).toEqual("key1");
-    expect(metadataFields[1]).toEqual("key2");
-    expect(metadataFields[2]).toEqual("key3");
-  });
-
-  it("Returns empty metadata", async () => {
-    (httpUtils.get as jest.Mock).mockImplementation(() => ({
-      workflow_runs: [
-        {
-          sample: {},
-        },
-      ],
-    }));
-
-    const result = await execute(query, {});
-
-    expect(result.data.fedConsensusGenomes[0].sequencingRead.sample.metadatas.edges).toHaveLength(0);
   });
 });
 
@@ -158,15 +80,18 @@ describe("fedConsensusGemomes SampleReport query:", () => {
             },
             accession: {
               accessionId: "MN908947.3",
-              accessionName: "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
+              accessionName:
+                "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
             },
           },
         ],
       },
     }));
-    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(() => true);
+    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(
+      () => true,
+    );
 
-    const result = await execute(query, {});
+    const result = await execute(query, { workflowRunId: "abc" });
 
     expect(result.data.fedConsensusGenomes).toHaveLength(1);
     expect(result.data.fedConsensusGenomes[0]).toEqual(
@@ -197,13 +122,17 @@ describe("fedConsensusGemomes SampleReport query:", () => {
         },
         accession: {
           accessionId: "MN908947.3",
-          accessionName: "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
+          accessionName:
+            "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
         },
       }),
     );
   });
+
   it("Returns data from rails", async () => {
-    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(() => false);
+    (httpUtils.shouldReadFromNextGen as jest.Mock).mockImplementation(
+      () => false,
+    );
     (httpUtils.get as jest.Mock).mockImplementation(() => ({
       coverage_viz: {
         total_length: 7056,
@@ -233,7 +162,8 @@ describe("fedConsensusGemomes SampleReport query:", () => {
       },
       taxon_info: {
         accession_id: "MG148341.1",
-        accession_name: "Rhinovirus C isolate CO03302015 polyprotein mRNA, complete cds\n",
+        accession_name:
+          "Rhinovirus C isolate CO03302015 polyprotein mRNA, complete cds\n",
         taxon_id: "463676",
         taxon_name: "Rhinovirus C",
       },
@@ -268,7 +198,8 @@ describe("fedConsensusGemomes SampleReport query:", () => {
         },
         accession: {
           accessionId: "MG148341.1",
-          accessionName: "Rhinovirus C isolate CO03302015 polyprotein mRNA, complete cds\n",
+          accessionName:
+            "Rhinovirus C isolate CO03302015 polyprotein mRNA, complete cds\n",
         },
       }),
     );

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -403,8 +403,8 @@ describe("sequencingReads query:", () => {
       convertSequencingReadsQuery(
         getExampleQuery("sequencing-reads-query-id-fe"),
       ),
-      `query ($where: SequencingReadWhereClause) {
-        sequencingReads(where: $where) {
+      `query ($where: SequencingReadWhereClause, $orderBy: [SequencingReadOrderByClause!]) {
+        sequencingReads(where: $where, orderBy: $orderBy) {
           id
           sample {
             railsSampleId

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -3978,7 +3978,12 @@ input queryInput_fedConsensusGenomes_input_todoRemove_Input {
 }
 
 input queryInput_fedConsensusGenomes_input_where_Input {
+  collectionId: queryInput_fedConsensusGenomes_input_where_collectionId_Input
   producingRunId: queryInput_fedConsensusGenomes_input_where_producingRunId_Input
+}
+
+input queryInput_fedConsensusGenomes_input_where_collectionId_Input {
+  _in: [Int]
 }
 
 input queryInput_fedConsensusGenomes_input_where_producingRunId_Input {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -3932,21 +3932,21 @@ input queryInput_fedBulkDownloads_input_Input @example(subgraph: "CZIDREST", val
 input queryInput_fedConsensusGenomes_input_Input {
   limit: Int
   offset: Int
-  orderBy: queryInput_fedConsensusGenomes_input_orderBy_Input
+  orderBy: [queryInput_fedConsensusGenomes_input_orderBy_items_Input]
   todoRemove: queryInput_fedConsensusGenomes_input_todoRemove_Input
   where: queryInput_fedConsensusGenomes_input_where_Input
 }
 
-input queryInput_fedConsensusGenomes_input_orderBy_Input {
-  accession: queryInput_fedConsensusGenomes_input_orderBy_accession_Input
-  metrics: queryInput_fedConsensusGenomes_input_orderBy_metrics_Input
+input queryInput_fedConsensusGenomes_input_orderBy_items_Input {
+  accession: queryInput_fedConsensusGenomes_input_orderBy_items_accession_Input
+  metrics: queryInput_fedConsensusGenomes_input_orderBy_items_metrics_Input
 }
 
-input queryInput_fedConsensusGenomes_input_orderBy_accession_Input {
+input queryInput_fedConsensusGenomes_input_orderBy_items_accession_Input {
   accessionId: String
 }
 
-input queryInput_fedConsensusGenomes_input_orderBy_metrics_Input {
+input queryInput_fedConsensusGenomes_input_orderBy_items_metrics_Input {
   coverageDepth: String
   gcPercent: String
   nActg: String
@@ -4937,6 +4937,7 @@ type query_fedConsensusGenomes_items_referenceGenome_file_downloadLink {
 }
 
 type query_fedConsensusGenomes_items_sequencingRead {
+  id: String!
   medakaModel: String
   nucleicAcid: String!
   protocol: String

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -53,15 +53,12 @@ export const convertValidateConsensusGenomeQuery = (query: string): string => {
   return (
     query
       // Replace Fed variables.
-      .replace(
-        /query [\s\S]*?{/,
-        "query ($where: WorkflowRunWhereClause) {",
-      )
+      .replace(/query [\s\S]*?{/, "query ($where: WorkflowRunWhereClause) {")
       // Remove fed prefix.
       .replace("fedWorkflowRuns", "workflowRuns")
       // Replace Fed arguments.
-      .replace(/input:[\s\S]*?\)/, "where: $where)")      
-  )
+      .replace(/input:[\s\S]*?\)/, "where: $where)")
+  );
 };
 
 export const convertWorkflowRunsQuery = (query: string): string => {
@@ -149,4 +146,19 @@ export const convertSequencingReadsQuery = (query: string): string => {
   }
 
   return query;
+};
+
+export const convertConsensusGenomesQuery = (query: string): string => {
+  return (
+    query
+      // Replace Fed variables.
+      .replace(
+        /query [\s\S]*?{/,
+        `query ($where: ConsensusGenomeWhereClause, $orderBy: [ConsensusGenomeOrderByClause!]!) {`,
+      )
+      // Remove fed prefix.
+      .replace("fedConsensusGenomes", "consensusGenomes")
+      // Replace Fed arguments.
+      .replace("input: $input", "where: $where, orderBy: $orderBy")
+  );
 };

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -97,7 +97,7 @@ export const convertSequencingReadsQuery = (query: string): string => {
           `query ($where: SequencingReadWhereClause, $orderBy: [SequencingReadOrderByClause!]) {`,
         )
         // Replace Fed arguments.
-        .replace("input: $input", "where: $where")
+        .replace("input: $input", "where: $where, orderBy: $orderBy")
         // Add railsSampleId field.
         .replace(
           /{\s*id\s*}/,

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -1,3 +1,6 @@
+/** Matches "query" until the first { encountered. */
+const QUERY_TO_BRACE_REGEX = /query [\s\S]*?{/;
+
 /**
  *
  * Transforms a query from the Front End one compatible with the Next Gen server
@@ -14,7 +17,6 @@
  * // returns "query ConsensusGenomeReportQuery($workflowRunId: UUID) {consensusGenomes( where: { id: { _eq: $workflowRunId }}) {...}}"
  *
  */
-
 export const formatFedQueryForNextGen = (query: string): string => {
   let cleanQuery = query;
   // remove fed Prefix
@@ -53,7 +55,7 @@ export const convertValidateConsensusGenomeQuery = (query: string): string => {
   return (
     query
       // Replace Fed variables.
-      .replace(/query [\s\S]*?{/, "query ($where: WorkflowRunWhereClause) {")
+      .replace(QUERY_TO_BRACE_REGEX, "query ($where: WorkflowRunWhereClause) {")
       // Remove fed prefix.
       .replace("fedWorkflowRuns", "workflowRuns")
       // Replace Fed arguments.
@@ -66,7 +68,7 @@ export const convertWorkflowRunsQuery = (query: string): string => {
     query
       // Replace Fed variables.
       .replace(
-        /query [\s\S]*?{/,
+        QUERY_TO_BRACE_REGEX,
         "query ($where: WorkflowRunWhereClause, $orderBy: [WorkflowRunOrderByClause!]) {",
       )
       // Remove fed prefix.
@@ -93,7 +95,7 @@ export const convertSequencingReadsQuery = (query: string): string => {
       query
         // Replace Fed variables.
         .replace(
-          /query [\s\S]*?{/,
+          QUERY_TO_BRACE_REGEX,
           `query ($where: SequencingReadWhereClause, $orderBy: [SequencingReadOrderByClause!]) {`,
         )
         // Replace Fed arguments.
@@ -114,7 +116,7 @@ export const convertSequencingReadsQuery = (query: string): string => {
   query = query
     // Replace Fed variables.
     .replace(
-      /query [\s\S]*?{/,
+      QUERY_TO_BRACE_REGEX,
       `query ($where: SequencingReadWhereClause, 
               $orderBy: [SequencingReadOrderByClause!], 
               $limitOffset: LimitOffsetClause, 
@@ -153,7 +155,7 @@ export const convertConsensusGenomesQuery = (query: string): string => {
     query
       // Replace Fed variables.
       .replace(
-        /query [\s\S]*?{/,
+        QUERY_TO_BRACE_REGEX,
         `query ($where: ConsensusGenomeWhereClause, $orderBy: [ConsensusGenomeOrderByClause!]!) {`,
       )
       // Remove fed prefix.

--- a/utils/queryFormatUtils.ts
+++ b/utils/queryFormatUtils.ts
@@ -94,7 +94,7 @@ export const convertSequencingReadsQuery = (query: string): string => {
         // Replace Fed variables.
         .replace(
           /query [\s\S]*?{/,
-          `query ($where: SequencingReadWhereClause) {`,
+          `query ($where: SequencingReadWhereClause, $orderBy: [SequencingReadOrderByClause!]) {`,
         )
         // Replace Fed arguments.
         .replace("input: $input", "where: $where")


### PR DESCRIPTION
# Pull Request

Note that this is getting rid of a lot of the previously written logic in this resolver for discovery view 🎉. We no longer need all that now that this query will not be used for actual paginated data, but only for generating the listed of filtered + sorted IDs.

Also fixes the `sequencingReads` query to NextGen not sending `orderBy`.
