### PR TITLE
feat: CZID-9499 Add referenceGenome to fedConsensusGenome

### DIFF
--- a/json-schemas/consensusGenomesResponse.json
+++ b/json-schemas/consensusGenomesResponse.json
@@ -194,6 +194,24 @@
                     }
                 },
                 "required": ["nucleicAcid", "technology"]
+            },
+            "referenceGenome": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "object",
+                    "properties": {
+                      "downloadLink": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
             }
         }
     }

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -75,6 +75,7 @@ export const resolvers: Resolvers = {
         return ret.data.consensusGenomes;
       }
       /* --------------------- Rails ------------------------- */
+      console.log(args.input)
       const input = args.input;
       if (input?.where?.producingRunId?._eq) {
         // if there is an _eq in the response than it is a call for a single workflow run result
@@ -88,6 +89,13 @@ export const resolvers: Resolvers = {
         const { coverage_viz, quality_metrics, taxon_info } = data;
         const { accession_id, accession_name, taxon_id, taxon_name } =
           taxon_info || {};
+
+        const referenceGenomeDownloadUrl = await get({
+          url: `/workflow_runs/${workflowRunId}/cg_report_downloads?downloadType=ref_fasta`,
+          args,
+          context,
+        });
+
         const ret = [
           {
             metrics: {
@@ -114,6 +122,13 @@ export const resolvers: Resolvers = {
               commonName: taxon_name,
               name: taxon_name,
             },
+            referenceGenome: {
+              file: {
+                downloadLink: {
+                  url: referenceGenomeDownloadUrl.url,
+                }
+              }
+            }
           },
         ];
         return ret;

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -4896,6 +4896,7 @@ type query_fedConsensusGenomes_items {
   accession: query_fedConsensusGenomes_items_accession
   metrics: query_fedConsensusGenomes_items_metrics
   producingRunId: String
+  referenceGenome: query_fedConsensusGenomes_items_referenceGenome
   sequencingRead: query_fedConsensusGenomes_items_sequencingRead
   taxon: query_fedConsensusGenomes_items_taxon
 }
@@ -4921,6 +4922,18 @@ type query_fedConsensusGenomes_items_metrics {
   refSnps: Int
   referenceGenomeLength: Float
   totalReads: Int
+}
+
+type query_fedConsensusGenomes_items_referenceGenome {
+  file: query_fedConsensusGenomes_items_referenceGenome_file
+}
+
+type query_fedConsensusGenomes_items_referenceGenome_file {
+  downloadLink: query_fedConsensusGenomes_items_referenceGenome_file_downloadLink
+}
+
+type query_fedConsensusGenomes_items_referenceGenome_file_downloadLink {
+  url: String
 }
 
 type query_fedConsensusGenomes_items_sequencingRead {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9499]

## Description
The Download Custom Reference button was not working with NextGen flags on because the call to get the download url was not federated.  This adds the field to fedConsensusGenome
<img width="408" alt="Screenshot 2024-03-27 at 4 26 15 PM" src="https://github.com/chanzuckerberg/czid-graphql-federation-server/assets/109251328/7e9f6d68-46dd-4656-9718-ff7c335576ce">

## Notes
I confirmed on Sandbox that this works when connected to rails.  It needs further testing for the connection to NextGen.

## Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*


[CZID-9499]: https://czi-tech.atlassian.net/browse/CZID-9499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ