### PR TITLE
Increase memory for prod server

### DIFF
--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -37,7 +37,7 @@ module "stack" {
     gql = merge(local.routing_config[local.service_type], {
       name              = "graphql-federation"
       port              = "4444"
-      memory            = "1500Mi"
+      memory            = "4000Mi"
       cpu               = "1500m"
       health_check_path = "/health"
       // INTERNAL - OIDC protected ALB


### PR DESCRIPTION
# Pull Request

## JIRA Ticket
N/A

## Description
Update terraform config to increase memory for all environments

## Notes

## Tests
- ran this manually in prod, branched off latest deployed released tag.  
  - https://github.com/chanzuckerberg/czid-graphql-federation-server/tree/20240328-bump-memory-in-prod
