### PR TITLE
fix: allow for deprecatedById field in aggregate queries

### DIFF
--- a/example-queries/workflow-runs-aggregate-total-count-query.graphql
+++ b/example-queries/workflow-runs-aggregate-total-count-query.graphql
@@ -12,6 +12,9 @@ query workflowRunsAggregateTotalCountQuery {
             }
           }
         }
+        deprecatedById: {
+          _is_null: true
+        }
       }
       todoRemove: { 
         domain: "my_data",

--- a/example-queries/workflows-aggregate-query.graphql
+++ b/example-queries/workflows-aggregate-query.graphql
@@ -15,6 +15,9 @@ query workflowRunsAggregateQuery {
             }
           }
         }
+        deprecatedById: {
+          _is_null: true
+        }
       }
       todoRemove: { 
         domain: "my_data",

--- a/json-schemas/fedWorkflowRunsAggregateTotalCountRequest.json
+++ b/json-schemas/fedWorkflowRunsAggregateTotalCountRequest.json
@@ -35,6 +35,14 @@
                             }
                         }
                     }
+                },
+                "deprecatedById": {
+                    "type": "object",
+                    "properties": {
+                        "_is_null": {
+                            "type": "boolean"
+                        }
+                    }
                 }
             }
         },

--- a/json-schemas/workflowRunsAggregateRequest.json
+++ b/json-schemas/workflowRunsAggregateRequest.json
@@ -46,6 +46,14 @@
                             }
                         }
                     }
+                },
+                "deprecatedById": {
+                    "type": "object",
+                    "properties": {
+                        "_is_null": {
+                            "type": "boolean"
+                        }
+                    }
                 }
             }
         },

--- a/sample-requests/fedWorkflowRunsAggregateTotalCount.json
+++ b/sample-requests/fedWorkflowRunsAggregateTotalCount.json
@@ -13,6 +13,9 @@
           ]
         }
       }
+    },
+    "deprecatedById": {
+      "_is_null": true
     }
   },
   "todoRemove": {

--- a/sample-requests/workflowRunsAggregate.json
+++ b/sample-requests/workflowRunsAggregate.json
@@ -16,6 +16,9 @@
           ]
         }
       }
+    },
+    "deprecatedById": {
+      "_is_null": true
     }
   },
   "todoRemove": {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -4281,11 +4281,16 @@ input queryInput_fedWorkflowRunsAggregateTotalCount_input_todoRemove_Input {
 
 input queryInput_fedWorkflowRunsAggregateTotalCount_input_where_Input {
   collectionId: queryInput_fedWorkflowRunsAggregateTotalCount_input_where_collectionId_Input
+  deprecatedById: queryInput_fedWorkflowRunsAggregateTotalCount_input_where_deprecatedById_Input
   workflowVersion: queryInput_fedWorkflowRunsAggregateTotalCount_input_where_workflowVersion_Input
 }
 
 input queryInput_fedWorkflowRunsAggregateTotalCount_input_where_collectionId_Input {
   _in: [Int]
+}
+
+input queryInput_fedWorkflowRunsAggregateTotalCount_input_where_deprecatedById_Input {
+  _is_null: Boolean
 }
 
 input queryInput_fedWorkflowRunsAggregateTotalCount_input_where_workflowVersion_Input {
@@ -4333,12 +4338,17 @@ input queryInput_fedWorkflowRunsAggregate_input_todoRemove_taxonThresholds_items
 
 input queryInput_fedWorkflowRunsAggregate_input_where_Input {
   collectionId: queryInput_fedWorkflowRunsAggregate_input_where_collectionId_Input
+  deprecatedById: queryInput_fedWorkflowRunsAggregate_input_where_deprecatedById_Input
   id: queryInput_fedWorkflowRunsAggregate_input_where_id_Input
   workflowVersion: queryInput_fedWorkflowRunsAggregate_input_where_workflowVersion_Input
 }
 
 input queryInput_fedWorkflowRunsAggregate_input_where_collectionId_Input {
   _in: [Int]
+}
+
+input queryInput_fedWorkflowRunsAggregate_input_where_deprecatedById_Input {
+  _is_null: Boolean
 }
 
 input queryInput_fedWorkflowRunsAggregate_input_where_id_Input {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket


## Description

Adds `deprecatedById` field to aggregate queries so we can filter out deprecated runs

## Notes


## Tests

Unit tests updated
