### PR TITLE
feat: Add producingRunId to request schema of sequencingReads

### DIFF
--- a/json-schemas/sequencingReadsRequest.json
+++ b/json-schemas/sequencingReadsRequest.json
@@ -113,6 +113,17 @@
                 "consensusGenomes": {
                     "type": "object",
                     "properties": {
+                        "producingRunId": {
+                            "type": "object",
+                            "properties": {
+                                "_in": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
                         "taxon": {
                             "type": "object",
                             "properties": {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -4219,7 +4219,12 @@ input queryInput_fedSequencingReads_input_where_collectionId_Input {
 }
 
 input queryInput_fedSequencingReads_input_where_consensusGenomes_Input {
+  producingRunId: queryInput_fedSequencingReads_input_where_consensusGenomes_producingRunId_Input
   taxon: queryInput_fedSequencingReads_input_where_consensusGenomes_taxon_Input
+}
+
+input queryInput_fedSequencingReads_input_where_consensusGenomes_producingRunId_Input {
+  _in: [String]
 }
 
 input queryInput_fedSequencingReads_input_where_consensusGenomes_taxon_Input {


### PR DESCRIPTION
# Pull Request

Allows us to filter out nested `ConsensusGenome`s that don't correspond to the filtered `WorkflowRun`s.

## Tests

Not used yet.
