### PR TITLE
fix: Use updated Rails endpoint for Bulk Download List

### DIFF
--- a/resolver-functions/fedBulkDownloads.ts
+++ b/resolver-functions/fedBulkDownloads.ts
@@ -27,6 +27,7 @@ export const fedBulkDowloadsResolver = async (root, args, context, info) => {
     args,
     context,
   });
+
   const mappedRes = res.map(async (bulkDownload, index) => {
     let url: string | null = null;
     let params: {
@@ -35,43 +36,46 @@ export const fedBulkDowloadsResolver = async (root, args, context, info) => {
       value: string;
     }[] = [];
     let entityInputs: any[] = [];
-    if (bulkDownload?.status === "success") {
-      try {
-        const details = await get({
-          url: `/bulk_downloads/${bulkDownload?.id}.json`,
-          args,
-          context,
-        });
-        url = details?.bulk_download?.presigned_output_url;
-        entityInputs = [
-          ...getEntityInputInfo(details?.bulk_download?.workflow_runs),
-          ...getEntityInputInfo(details?.bulk_download?.pipeline_runs),
-        ];
-        if (typeof details?.bulk_download?.params === "object") {
-          Object.entries(details?.bulk_download?.params)
-            // remove "workflow" and "sample_ids" from details?.bulk_download?.params
-            .filter(
-              param => param[0] !== "workflow" && param[0] !== "sample_ids",
-            )
-            // make params into an array of objects
-            .map(
-              (param: [string, { downloadName?: string; value: string }]) => {
-                const paramItem = {
-                  paramType: snakeToCamel(param[0]),
-                  ...param[1],
-                };
-                params.push(paramItem);
-              },
-            );
-        }
-      } catch (e) {
-        console.error(
-          `Error fetching bulk download details for bulk download id ${bulkDownload?.id}`,
-          e,
-          bulkDownload?.created_at,
-        );
-      }
+    if (index < 8) {
+      console.log(bulkDownload.download_type_details);
     }
+    // if (bulkDownload?.status === "success") {
+    // try {
+    //   const details = await get({
+    //     url: `/bulk_downloads/${bulkDownload?.id}.json`,
+    //     args,
+    //     context,
+    //   });
+    //   url = details?.bulk_download?.presigned_output_url;
+    //   entityInputs = [
+    //     ...getEntityInputInfo(details?.bulk_download?.workflow_runs),
+    //     ...getEntityInputInfo(details?.bulk_download?.pipeline_runs),
+    //   ];
+    //   if (typeof details?.bulk_download?.params === "object") {
+    //     Object.entries(details?.bulk_download?.params)
+    //       // remove "workflow" and "sample_ids" from details?.bulk_download?.params
+    //       .filter(
+    //         param => param[0] !== "workflow" && param[0] !== "sample_ids",
+    //       )
+    //       // make params into an array of objects
+    //       .map(
+    //         (param: [string, { downloadName?: string; value: string }]) => {
+    //           const paramItem = {
+    //             paramType: snakeToCamel(param[0]),
+    //             ...param[1],
+    //           };
+    //           params.push(paramItem);
+    //         },
+    //       );
+    //   }
+    // } catch (e) {
+    //   console.error(
+    //     `Error fetching bulk download details for bulk download id ${bulkDownload?.id}`,
+    //     e,
+    //     bulkDownload?.created_at,
+    //   );
+    // }
+    // }
     const {
       id,
       status,

--- a/resolver-functions/fedBulkDownloads.ts
+++ b/resolver-functions/fedBulkDownloads.ts
@@ -37,7 +37,18 @@ export const fedBulkDowloadsResolver = async (root, args, context, info) => {
     }[] = [];
     let entityInputs: any[] = [];
     if (index < 8) {
-      console.log(bulkDownload.download_type_details);
+      console.log(bulkDownload?.download_type_details);
+    }
+    if (bulkDownload?.download_type_details) {
+      url = bulkDownload?.download_type_details?.presigned_output_url;
+      entityInputs = [
+        ...getEntityInputInfo(
+          bulkDownload?.download_type_details?.workflow_runs,
+        ),
+        ...getEntityInputInfo(
+          bulkDownload?.download_type_details?.pipeline_runs,
+        ),
+      ];
     }
     // if (bulkDownload?.status === "success") {
     // try {

--- a/resolver-functions/fedBulkDownloads.ts
+++ b/resolver-functions/fedBulkDownloads.ts
@@ -37,18 +37,18 @@ export const fedBulkDowloadsResolver = async (root, args, context, info) => {
     }[] = [];
     let entityInputs: any[] = [];
     if (index < 8) {
-      console.log(bulkDownload?.download_type_details);
+      console.log("bulk download", bulkDownload);
     }
     if (bulkDownload?.download_type_details) {
       url = bulkDownload?.download_type_details?.presigned_output_url;
-      entityInputs = [
-        ...getEntityInputInfo(
-          bulkDownload?.download_type_details?.workflow_runs,
-        ),
-        ...getEntityInputInfo(
-          bulkDownload?.download_type_details?.pipeline_runs,
-        ),
-      ];
+      // entityInputs = [
+      //   ...getEntityInputInfo(
+      //     bulkDownload?.download_type_details?.workflow_runs,
+      //   ),
+      //   ...getEntityInputInfo(
+      //     bulkDownload?.download_type_details?.pipeline_runs,
+      //   ),
+      // ];
     }
     // if (bulkDownload?.status === "success") {
     // try {

--- a/resolver-functions/fedBulkDownloads/fedBulkDownloads.test.ts
+++ b/resolver-functions/fedBulkDownloads/fedBulkDownloads.test.ts
@@ -1,9 +1,9 @@
 import { ExecuteMeshFn } from "@graphql-mesh/runtime";
-import { getMeshInstance } from "./utils/MeshInstance";
+import { getMeshInstance } from "../../tests/utils/MeshInstance";
 
-import * as httpUtils from "../utils/httpUtils";
-import { getExampleQuery } from "./utils/ExampleQueryFiles";
-jest.mock("../utils/httpUtils");
+import * as httpUtils from "../../utils/httpUtils";
+import { getExampleQuery } from "../../tests/utils/ExampleQueryFiles";
+jest.mock("../../utils/httpUtils");
 
 beforeEach(async () => {
   (httpUtils.get as jest.Mock).mockClear();
@@ -70,41 +70,8 @@ describe("bulkDownloads Query:", () => {
 
   it("should give correct response with url params & successful run", async () => {
     const query = getExampleQuery("bulk-downloads-with-limit");
-    const railsResponse = [
-      {
+    const railsResponse = [{
         id: 12715,
-        params_json:
-          '{"sample_ids":{"value":[24682,25015,25160]},"workflow":{"value":"short-read-mngs"},"background":{"value":350,"displayName":"floo sp86"}}',
-        download_type: "sample_taxon_report",
-        status: "success",
-        error_message: null,
-        user_id: 412,
-        created_at: "2024-02-15T11:52:57.000-08:00",
-        updated_at: "2024-02-15T11:53:22.000-08:00",
-        progress: 0.87,
-        ecs_task_arn: null,
-        output_file_size: 57197,
-        description: null,
-        deleted_at: null,
-        analysis_type: "short-read-mngs",
-        analysis_count: 3,
-        num_samples: 3,
-        download_name: "Sample Taxon Reports",
-        file_size: "55.9 KB",
-        user_name: "Suzette McCanny",
-        execution_type: "resque",
-        log_url: null,
-        params: {
-          sample_ids: { value: [24682, 25015, 25160] },
-          workflow: ["short-read-mngs"],
-        },
-      },
-    ];
-    const railsResponse2 = {
-      bulk_download: {
-        id: 12715,
-        params_json:
-          '{"sample_ids":{"value":[24682,25015,25160]},"workflow":{"value":"short-read-mngs"},"background":{"value":350,"displayName":"floo sp86"}}',
         download_type: "sample_taxon_report",
         status: "success",
         error_message: null,
@@ -135,20 +102,8 @@ describe("bulkDownloads Query:", () => {
         ],
         workflow_runs: [],
         presigned_output_url: "https://presignedUrl.com",
-      },
-      download_type: {
-        type: "sample_taxon_report",
-        display_name: "Sample Taxon Reports",
-        description:
-          "Computed metrics (e.g. total reads, rPM) and metadata for each taxon identified in the sample",
-        category: "reports",
-        execution_type: "resque",
-        file_type_display: ".csv",
-        workflows: ["short-read-mngs"],
-      },
-    };
+    }];
     (httpUtils.get as jest.Mock).mockImplementationOnce(() => railsResponse);
-    (httpUtils.get as jest.Mock).mockImplementationOnce(() => railsResponse2);
     const result = await execute(query, {
       limit: 2,
       searchBy: "Suzette McCanny",
@@ -182,6 +137,7 @@ describe("bulkDownloads Query:", () => {
         params: [],
       },
     ];
+    console.log(result);
     expect(result.data.fedBulkDownloads).toStrictEqual(bulkDownloadResponse);
   });
 });

--- a/resolver-functions/fedBulkDownloads/fedBulkDownloads.test.ts
+++ b/resolver-functions/fedBulkDownloads/fedBulkDownloads.test.ts
@@ -137,7 +137,6 @@ describe("bulkDownloads Query:", () => {
         params: [],
       },
     ];
-    console.log(result);
     expect(result.data.fedBulkDownloads).toStrictEqual(bulkDownloadResponse);
   });
 });

--- a/resolver-functions/fedBulkDownloads/fedBulkDownloads.ts
+++ b/resolver-functions/fedBulkDownloads/fedBulkDownloads.ts
@@ -54,7 +54,6 @@ export const fedBulkDowloadsResolver = async (root, args, context, info) => {
     args,
     context,
   });
-  console.log(res);
   const mappedRes = res.map(async (bulkDownload: BulkDownloadFromRails) => {
     const entityInputs = [
       ...getEntityInputInfo(bulkDownload?.workflow_runs),

--- a/resolver-functions/fedBulkDownloads/fedBulkDownloads.ts
+++ b/resolver-functions/fedBulkDownloads/fedBulkDownloads.ts
@@ -1,6 +1,6 @@
-import { get } from "../utils/httpUtils";
-import { formatUrlParams } from "../utils/paramsUtils";
-import { snakeToCamel } from "../utils/utils";
+import { get } from "../../utils/httpUtils";
+import { formatUrlParams } from "../../utils/paramsUtils";
+import { snakeToCamel } from "../../utils/utils";
 
 interface BulkDownloadFromRails {
   id: number;
@@ -54,7 +54,7 @@ export const fedBulkDowloadsResolver = async (root, args, context, info) => {
     args,
     context,
   });
-
+  console.log(res);
   const mappedRes = res.map(async (bulkDownload: BulkDownloadFromRails) => {
     const entityInputs = [
       ...getEntityInputInfo(bulkDownload?.workflow_runs),

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -10,7 +10,7 @@ import {
 } from "./.mesh";
 import { SampleForReportResolver } from "./resolver-functions/SampleForReport";
 import { BulkDownloadsCGOverviewResolver } from "./resolver-functions/BulkDownloadsCGOverview";
-import { fedBulkDowloadsResolver } from "./resolver-functions/fedBulkDownloads";
+import { fedBulkDowloadsResolver } from "./resolver-functions/fedBulkDownloads/fedBulkDownloads";
 import { parseWorkflowsAggregateTotalCountsResponse, processWorkflowsAggregateResponse } from "./utils/aggregateUtils";
 import {
   fetchFromNextGen,


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

no ticket 

## Description

Consume new merged bulk download rails endpoint that has all the data in one call so that we don't have to make multliple calls to the details endpoint. 

Final fix for undefined bug. 

## Notes

Dependant on this PR https://github.com/chanzuckerberg/czid-web-private/pull/4478

## Tests

- Should be able to load `/bulk_downloads` without undefined errors
