### PR TITLE
fix: Add taxon level to fedSequencingReads

### DIFF
--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -126,6 +126,9 @@
                                             "properties": {
                                                 "name": {
                                                     "type": "string"
+                                                },
+                                                "level": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": ["name"]

--- a/json-schemas/sequencingReadsResponse.json
+++ b/json-schemas/sequencingReadsResponse.json
@@ -23,6 +23,9 @@
                 "properties": {
                     "name": {
                         "type": "string"
+                    },
+                    "level": {
+                        "type": "string"
                     }
                 },
                 "required": ["name"]

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -5149,6 +5149,7 @@ type query_fedSequencingReads_items_sample_metadatas_edges_items_node {
 }
 
 type query_fedSequencingReads_items_taxon {
+  level: String
   name: String!
 }
 

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -5107,6 +5107,7 @@ type query_fedSequencingReads_items_consensusGenomes_edges_items_node_referenceG
 }
 
 type query_fedSequencingReads_items_consensusGenomes_edges_items_node_taxon {
+  level: String
   name: String!
 }
 


### PR DESCRIPTION
# Pull Request

## JIRA Ticket
none

## Description
makes the taxon level available

## Notes
I'm not sure why the snapshot update changed some dates from DateTime to ISO8601DateTime here, but it seems ok?

## Tests
updated snapshot
