### PR TITLE
feat: Upgrade Mesh again to enable error logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.29.3",
       "license": "ISC",
       "dependencies": {
-        "@graphql-mesh/cli": "0.89.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+        "@graphql-mesh/cli": "^0.89.9",
         "@graphql-mesh/graphql": "^0.97.0",
         "@graphql-mesh/json-schema": "^0.99.0",
         "@graphql-mesh/transform-encapsulate": "^0.97.0",
@@ -1235,14 +1235,30 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@envelop/graphql-jit/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@envelop/graphql-jit/node_modules/fast-json-stringify": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.13.0.tgz",
-      "integrity": "sha512-XjTDWKHP3GoMQUOfnjYUbqeHeEt+PvYgvBdG2fRSmYaORILbSr8xTJvZX+w1YSAP5pw2NwKrGRmQleYueZEoxw==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.14.1.tgz",
+      "integrity": "sha512-J1Grbf0oSXV3lKsBf3itz1AvRk43qVrx3Ac10sNvi3LZaz1by4oDdYKFrJycPhS8+Gb7y8rgV/Jqw1UZVjyNvw==",
       "dependencies": {
         "@fastify/merge-json-schemas": "^0.1.0",
         "ajv": "^8.10.0",
-        "ajv-formats": "^2.1.1",
+        "ajv-formats": "^3.0.1",
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^2.1.0",
         "json-schema-ref-resolver": "^1.0.1",
@@ -1578,9 +1594,9 @@
       }
     },
     "node_modules/@graphql-mesh/cli": {
-      "version": "0.89.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cli/-/cli-0.89.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a.tgz",
-      "integrity": "sha512-NwT723Knwk9tUq7coGiippjf5Rb1P+Kuv/aEdWvUKDuO55VEvY+bu99f8sZTegHFDbXNsZKZ4EYOJId7UkWRFA==",
+      "version": "0.89.9",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cli/-/cli-0.89.9.tgz",
+      "integrity": "sha512-JZ8TlstarYex2yxIYJJCBbOzpQM8mGScPpMqUAQyyYd95Rg/Q2cYBlUy4+KsxdBoioDSYmtGKqmp7q00IFxDxA==",
       "dependencies": {
         "@graphql-codegen/core": "^4.0.0",
         "@graphql-codegen/typed-document-node": "^5.0.0",
@@ -1588,10 +1604,10 @@
         "@graphql-codegen/typescript-generic-sdk": "^3.1.0",
         "@graphql-codegen/typescript-operations": "^4.0.0",
         "@graphql-codegen/typescript-resolvers": "^4.0.0",
-        "@graphql-mesh/config": "0.99.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+        "@graphql-mesh/config": "^0.99.9",
         "@graphql-mesh/cross-helpers": "^0.4.1",
-        "@graphql-mesh/http": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
-        "@graphql-mesh/runtime": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+        "@graphql-mesh/http": "^0.98.8",
+        "@graphql-mesh/runtime": "^0.98.8",
         "@graphql-mesh/store": "^0.97.5",
         "@graphql-mesh/types": "^0.97.5",
         "@graphql-mesh/utils": "^0.97.5",
@@ -1632,9 +1648,9 @@
       }
     },
     "node_modules/@graphql-mesh/config": {
-      "version": "0.99.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/config/-/config-0.99.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a.tgz",
-      "integrity": "sha512-1S4O0e2xW1nVrCNnCFbd7VEIdYw+plgfUfzloWNpZGPSnuEgrK9Hvk3nVD3YM1yunsOUnpccTF0ItxtYIJcojg==",
+      "version": "0.99.9",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/config/-/config-0.99.9.tgz",
+      "integrity": "sha512-NUibt2GLcgiBYjsJ4JGjsoZwg8Cx+8gMXdJpKbfmkRfd8vKilm5u1vXoJCK/L+2m/ZP4qkGIRjFEk2d1lubSmQ==",
       "dependencies": {
         "@envelop/core": "^5.0.0",
         "@graphql-mesh/cache-localforage": "^0.97.5",
@@ -1654,7 +1670,7 @@
       },
       "peerDependencies": {
         "@graphql-mesh/cross-helpers": "^0.4.1",
-        "@graphql-mesh/runtime": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+        "@graphql-mesh/runtime": "^0.98.8",
         "@graphql-mesh/store": "^0.97.5",
         "@graphql-mesh/types": "^0.97.5",
         "@graphql-mesh/utils": "^0.97.5",
@@ -1703,9 +1719,9 @@
       }
     },
     "node_modules/@graphql-mesh/http": {
-      "version": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/http/-/http-0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a.tgz",
-      "integrity": "sha512-wugFtWTLd+3Q6urNr8e8Alq/hfKxOtGUemnlhtLp2oHIpWTsHOOPsyPFhKNRF4Mw5dffPW/o5p4UnnrI/61TZw==",
+      "version": "0.98.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/http/-/http-0.98.8.tgz",
+      "integrity": "sha512-MFmExMMNF2ZYsKebSguV/sIcjZKfmkdCnW9ZzmDYUlF8lb0oItAA4J693km/1f494xh57wC3wBtkEPgEBf+AJA==",
       "dependencies": {
         "@whatwg-node/server": "^0.9.0",
         "graphql-yoga": "^5.1.1"
@@ -1715,9 +1731,10 @@
       },
       "peerDependencies": {
         "@graphql-mesh/cross-helpers": "^0.4.1",
-        "@graphql-mesh/runtime": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+        "@graphql-mesh/runtime": "^0.98.8",
         "@graphql-mesh/types": "^0.97.5",
         "@graphql-mesh/utils": "^0.97.5",
+        "@graphql-tools/utils": "^9.2.1 || ^10.0.0",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
@@ -1786,9 +1803,9 @@
       }
     },
     "node_modules/@graphql-mesh/runtime": {
-      "version": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/runtime/-/runtime-0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a.tgz",
-      "integrity": "sha512-tTKaba8OqrN7/QUPA4AOOuGJwYuJZCI8STQDuWMVFXoC+VjmJ+KSlBQvp3tW8SVqDvQlnqYCUUw6qB0KLL21yw==",
+      "version": "0.98.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/runtime/-/runtime-0.98.8.tgz",
+      "integrity": "sha512-s8EVdZbWI0r5kvQwDTobc8rU2ox+cGCv6vWGbmdN1NUwKDi4W8Fcisyc/2k7xX+FzCcW3uknlmE3sIbLVsmzUQ==",
       "dependencies": {
         "@envelop/core": "^5.0.0",
         "@envelop/extended-validation": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.29.3",
       "license": "ISC",
       "dependencies": {
-        "@graphql-mesh/cli": "^0.89.8",
+        "@graphql-mesh/cli": "0.89.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
         "@graphql-mesh/graphql": "^0.97.0",
         "@graphql-mesh/json-schema": "^0.99.0",
         "@graphql-mesh/transform-encapsulate": "^0.97.0",
@@ -1578,9 +1578,9 @@
       }
     },
     "node_modules/@graphql-mesh/cli": {
-      "version": "0.89.8",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cli/-/cli-0.89.8.tgz",
-      "integrity": "sha512-tN9PKac0XxwIcDrYwKZNDQra/3n0qNR/fPzXMbg+LhPLItcMjnDPKi8E0GGxTR5H/b/EUjPRflz4r9pRwQYyxA==",
+      "version": "0.89.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cli/-/cli-0.89.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a.tgz",
+      "integrity": "sha512-NwT723Knwk9tUq7coGiippjf5Rb1P+Kuv/aEdWvUKDuO55VEvY+bu99f8sZTegHFDbXNsZKZ4EYOJId7UkWRFA==",
       "dependencies": {
         "@graphql-codegen/core": "^4.0.0",
         "@graphql-codegen/typed-document-node": "^5.0.0",
@@ -1588,10 +1588,10 @@
         "@graphql-codegen/typescript-generic-sdk": "^3.1.0",
         "@graphql-codegen/typescript-operations": "^4.0.0",
         "@graphql-codegen/typescript-resolvers": "^4.0.0",
-        "@graphql-mesh/config": "^0.99.8",
+        "@graphql-mesh/config": "0.99.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
         "@graphql-mesh/cross-helpers": "^0.4.1",
-        "@graphql-mesh/http": "^0.98.7",
-        "@graphql-mesh/runtime": "^0.98.7",
+        "@graphql-mesh/http": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+        "@graphql-mesh/runtime": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
         "@graphql-mesh/store": "^0.97.5",
         "@graphql-mesh/types": "^0.97.5",
         "@graphql-mesh/utils": "^0.97.5",
@@ -1632,9 +1632,9 @@
       }
     },
     "node_modules/@graphql-mesh/config": {
-      "version": "0.99.8",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/config/-/config-0.99.8.tgz",
-      "integrity": "sha512-MQ5MVlnVzmeZ1mNFa5ap51kZEDuPTTBrodNUhPlaYbun1bFSt+jACicOiFDVgQ9uHcjNg4v+q78nwzXdUyHeGg==",
+      "version": "0.99.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/config/-/config-0.99.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a.tgz",
+      "integrity": "sha512-1S4O0e2xW1nVrCNnCFbd7VEIdYw+plgfUfzloWNpZGPSnuEgrK9Hvk3nVD3YM1yunsOUnpccTF0ItxtYIJcojg==",
       "dependencies": {
         "@envelop/core": "^5.0.0",
         "@graphql-mesh/cache-localforage": "^0.97.5",
@@ -1654,7 +1654,7 @@
       },
       "peerDependencies": {
         "@graphql-mesh/cross-helpers": "^0.4.1",
-        "@graphql-mesh/runtime": "^0.98.7",
+        "@graphql-mesh/runtime": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
         "@graphql-mesh/store": "^0.97.5",
         "@graphql-mesh/types": "^0.97.5",
         "@graphql-mesh/utils": "^0.97.5",
@@ -1703,9 +1703,9 @@
       }
     },
     "node_modules/@graphql-mesh/http": {
-      "version": "0.98.7",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/http/-/http-0.98.7.tgz",
-      "integrity": "sha512-KWoQ58CS5Hl7ONbO7ClElOPbRX7JOeR4yxoypexHahfaWjAoUuF7kVGwRFeVzZiT2HEz3J+fGIx+vlBCD5yp6w==",
+      "version": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/http/-/http-0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a.tgz",
+      "integrity": "sha512-wugFtWTLd+3Q6urNr8e8Alq/hfKxOtGUemnlhtLp2oHIpWTsHOOPsyPFhKNRF4Mw5dffPW/o5p4UnnrI/61TZw==",
       "dependencies": {
         "@whatwg-node/server": "^0.9.0",
         "graphql-yoga": "^5.1.1"
@@ -1715,7 +1715,7 @@
       },
       "peerDependencies": {
         "@graphql-mesh/cross-helpers": "^0.4.1",
-        "@graphql-mesh/runtime": "^0.98.7",
+        "@graphql-mesh/runtime": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
         "@graphql-mesh/types": "^0.97.5",
         "@graphql-mesh/utils": "^0.97.5",
         "graphql": "*",
@@ -1786,9 +1786,9 @@
       }
     },
     "node_modules/@graphql-mesh/runtime": {
-      "version": "0.98.7",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/runtime/-/runtime-0.98.7.tgz",
-      "integrity": "sha512-8ytRY9F/7fWj5xIX14WgJBUtoJ3OB5mbIsu8ZtK0KJuHgZw7/S9pu0tBeROWFhMcrI7Y0yKIWgo4jx4eT29t0g==",
+      "version": "0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/runtime/-/runtime-0.98.8-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a.tgz",
+      "integrity": "sha512-tTKaba8OqrN7/QUPA4AOOuGJwYuJZCI8STQDuWMVFXoC+VjmJ+KSlBQvp3tW8SVqDvQlnqYCUUw6qB0KLL21yw==",
       "dependencies": {
         "@envelop/core": "^5.0.0",
         "@envelop/extended-validation": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/chanzuckerberg/graphql-federation-server#readme",
   "dependencies": {
-    "@graphql-mesh/cli": "0.89.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
+    "@graphql-mesh/cli": "^0.89.9",
     "@graphql-mesh/graphql": "^0.97.0",
     "@graphql-mesh/json-schema": "^0.99.0",
     "@graphql-mesh/transform-encapsulate": "^0.97.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/chanzuckerberg/graphql-federation-server#readme",
   "dependencies": {
-    "@graphql-mesh/cli": "^0.89.8",
+    "@graphql-mesh/cli": "0.89.9-alpha-20240404080745-2253ba46f7b295c44299693a110cdb2c840c1b0a",
     "@graphql-mesh/graphql": "^0.97.0",
     "@graphql-mesh/json-schema": "^0.99.0",
     "@graphql-mesh/transform-encapsulate": "^0.97.0",

--- a/utils/httpUtils.ts
+++ b/utils/httpUtils.ts
@@ -26,7 +26,6 @@ export const get = async ({
         args,
         context,
         serviceType,
-        fullResponse,
         customQuery,
         securityToken,
       });
@@ -97,7 +96,6 @@ export const fetchFromNextGen = async ({
   args,
   context,
   serviceType,
-  fullResponse,
   customQuery,
   customVariables,
   securityToken,
@@ -105,7 +103,6 @@ export const fetchFromNextGen = async ({
   args;
   context;
   serviceType: "workflows" | "entities";
-  fullResponse?: boolean;
   customQuery?: string;
   customVariables?: object;
   securityToken?: string;
@@ -136,11 +133,13 @@ export const fetchFromNextGen = async ({
       }),
     });
 
-    if (fullResponse === true) {
-      return response;
-    } else {
-      return await response.json();
+    const responseJson = await response.json();
+    if (responseJson.errors?.length) {
+      throw new Error(
+        `${responseJson.errors.length} error(s) from NextGen: ${responseJson.errors.map((error, i) => `${i + 1}. ${error.message}`).join(" ")}`,
+      );
     }
+    return responseJson;
   } catch (e) {
     handleFetchError(e);
   }


### PR DESCRIPTION
# Pull Request

The new version of Mesh adds the implementation for making `Error`s get logged.

For whatever reason, Node.js's `json()` function doesn't return an `Error` with a stacktrace, so we have to manually catch that and throw a real `Error` if we want a stacktrace from it.

I also switched the `Promise.reject()`s to just `throw`s since it's a bit more concise.
