### PR TITLE
fix: Handle object type in collection_location_v2

### DIFF
--- a/resolvers.ts
+++ b/resolvers.ts
@@ -562,13 +562,17 @@ export const resolvers: Resolvers = {
           const nextGenSample = nextGenSequencingRead.sample;
           const railsSample = railsSamplesById.get(nextGenSample.railsSampleId);
 
-          const railsMetadata = railsSample?.details?.metadata;
+          const railsMetadata:
+            | { [key: string]: string | { name: string } }
+            | undefined = railsSample?.details?.metadata;
           const railsDbSample = railsSample?.details?.db_sample;
 
           nextGenSequencingRead.nucleicAcid =
             railsMetadata?.nucleotide_type ?? "";
           nextGenSample.collectionLocation =
-            railsMetadata?.collection_location_v2 ?? "";
+            typeof railsMetadata?.collection_location_v2 === "string"
+              ? railsMetadata.collection_location_v2
+              : railsMetadata?.collection_location_v2?.name ?? "";
           nextGenSample.sampleType = railsMetadata?.sample_type ?? "";
           nextGenSample.waterControl = railsMetadata?.water_control === "Yes";
           nextGenSample.notes = railsDbSample?.sample_notes;

--- a/resolvers.ts
+++ b/resolvers.ts
@@ -564,6 +564,7 @@ export const resolvers: Resolvers = {
 
           const railsMetadata:
             | { [key: string]: string | { name: string } }
+            | null
             | undefined = railsSample?.details?.metadata;
           const railsDbSample = railsSample?.details?.db_sample;
 

--- a/tests/SequencingReadsQuery.test.ts
+++ b/tests/SequencingReadsQuery.test.ts
@@ -484,7 +484,7 @@ describe("sequencingReads query:", () => {
                 project_name: "Project B",
               },
               metadata: {
-                collection_location_v2: "Mexico",
+                collection_location_v2: { name: "Mexico" },
                 custom2: "Custom value 2",
               },
             },


### PR DESCRIPTION
# Pull Request

`collection_location_v2` is the only metadata field that is sometimes an object.

This was actually handled in the old `consensusGenomes` endpoint, but I forgot to also add the fix to `sequencingReads`.
