### PR TITLE
fix: Update collectionId in workflow schema to be nullable

### DIFF
--- a/sources/nextgen-workflows-schema.graphql
+++ b/sources/nextgen-workflows-schema.graphql
@@ -119,7 +119,7 @@ type Query {
 }
 
 input RunWorkflowVersionInput {
-  collectionId: Int!
+  collectionId: Int = null
   workflowVersionId: ID!
   entityInputs: [EntityInputType!]
   rawInputJson: String
@@ -185,7 +185,7 @@ type Workflow implements EntityInterface & Node {
   ): WorkflowVersionConnection!
   versionsAggregate(where: WorkflowVersionWhereClause = null): WorkflowVersionAggregate
   ownerUserId: Int!
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   updatedAt: DateTime
   deletedAt: DateTime
@@ -223,7 +223,7 @@ input WorkflowCreateInput {
   name: String = null
   defaultVersion: String = null
   minimumSupportedVersion: String = null
-  collectionId: Int!
+  collectionId: Int = null
   deletedAt: DateTime = null
 }
 
@@ -316,7 +316,7 @@ type WorkflowRun implements EntityInterface & Node {
   entityInputsAggregate(where: WorkflowRunEntityInputWhereClause = null): WorkflowRunEntityInputAggregate
   rawInputsJson: String
   ownerUserId: Int!
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   updatedAt: DateTime
   deletedAt: DateTime
@@ -386,7 +386,7 @@ type WorkflowRunEntityInput implements EntityInterface & Node {
   entityType: String
   workflowRun(where: WorkflowRunWhereClause = null, orderBy: [WorkflowRunOrderByClause!] = []): WorkflowRun
   ownerUserId: Int!
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   updatedAt: DateTime
   deletedAt: DateTime
@@ -434,7 +434,7 @@ input WorkflowRunEntityInputCreateInput {
   fieldName: String = null
   entityType: String = null
   workflowRunId: ID = null
-  collectionId: Int!
+  collectionId: Int = null
   deletedAt: DateTime = null
 }
 
@@ -600,7 +600,7 @@ type WorkflowRunStep implements EntityInterface & Node {
   endedAt: DateTime
   status: WorkflowRunStepStatus
   ownerUserId: Int!
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   updatedAt: DateTime
   deletedAt: DateTime
@@ -647,7 +647,7 @@ input WorkflowRunStepCreateInput {
   workflowRunId: ID = null
   endedAt: DateTime = null
   status: WorkflowRunStepStatus = null
-  collectionId: Int!
+  collectionId: Int = null
   deletedAt: DateTime = null
 }
 
@@ -814,7 +814,7 @@ type WorkflowVersion implements EntityInterface & Node {
   ): WorkflowRunConnection!
   runsAggregate(where: WorkflowRunWhereClause = null): WorkflowRunAggregate
   ownerUserId: Int!
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   updatedAt: DateTime
   deletedAt: DateTime
@@ -867,7 +867,7 @@ input WorkflowVersionCreateInput {
   manifest: String = null
   workflowId: ID = null
   deprecated: Boolean = null
-  collectionId: Int!
+  collectionId: Int = null
   deletedAt: DateTime = null
 }
 

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -1985,7 +1985,7 @@ input ReferenceGenomeWhereClauseMutations {
 }
 
 input RunWorkflowVersionInput {
-  collectionId: Int!
+  collectionId: Int = null
   entityInputs: [EntityInputType!]
   railsWorkflowRunId: Int = null
   rawInputJson: String
@@ -2997,7 +2997,7 @@ type ValidateUserCanDeleteObjects {
 type Workflow implements EntityInterface & Node {
   """The Globally Unique ID of this object"""
   _id: GlobalID!
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   defaultVersion: String
   deletedAt: DateTime
@@ -3050,7 +3050,7 @@ enum WorkflowCountColumns {
 }
 
 input WorkflowCreateInput {
-  collectionId: Int!
+  collectionId: Int = null
   defaultVersion: String = null
   deletedAt: DateTime = null
   minimumSupportedVersion: String = null
@@ -3101,7 +3101,7 @@ type WorkflowRun implements EntityInterface & Node {
   """The Globally Unique ID of this object"""
   _id: GlobalID!
   cachedResults: String
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   deletedAt: DateTime
   deprecated: Boolean!
@@ -3212,7 +3212,7 @@ type WorkflowRunEdge {
 type WorkflowRunEntityInput implements EntityInterface & Node {
   """The Globally Unique ID of this object"""
   _id: GlobalID!
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   deletedAt: DateTime
   entityType: String
@@ -3261,7 +3261,7 @@ enum WorkflowRunEntityInputCountColumns {
 }
 
 input WorkflowRunEntityInputCreateInput {
-  collectionId: Int!
+  collectionId: Int = null
   deletedAt: DateTime = null
   entityType: String = null
   fieldName: String = null
@@ -3424,7 +3424,7 @@ input WorkflowRunStatusEnumComparators {
 type WorkflowRunStep implements EntityInterface & Node {
   """The Globally Unique ID of this object"""
   _id: GlobalID!
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   deletedAt: DateTime
   endedAt: DateTime
@@ -3473,7 +3473,7 @@ enum WorkflowRunStepCountColumns {
 }
 
 input WorkflowRunStepCreateInput {
-  collectionId: Int!
+  collectionId: Int = null
   deletedAt: DateTime = null
   endedAt: DateTime = null
   status: WorkflowRunStepStatus = null
@@ -3617,7 +3617,7 @@ input WorkflowUpdateInput {
 type WorkflowVersion implements EntityInterface & Node {
   """The Globally Unique ID of this object"""
   _id: GlobalID!
-  collectionId: Int!
+  collectionId: Int
   createdAt: DateTime!
   deletedAt: DateTime
   deprecated: Boolean
@@ -3684,7 +3684,7 @@ enum WorkflowVersionCountColumns {
 }
 
 input WorkflowVersionCreateInput {
-  collectionId: Int!
+  collectionId: Int = null
   deletedAt: DateTime = null
   deprecated: Boolean = null
   graphJson: String = null


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9505]

## Description

Update the nextGen workflow schema in the source file to pick up the following updates:
* Allow `collectionId` on workflowRuns to be null

See the platformics PR for more details: https://github.com/chanzuckerberg/czid-platformics/pull/282

## Notes

N/A

## Tests

N/A


[CZID-9505]: https://czi-tech.atlassian.net/browse/CZID-9505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ