### PR TITLE
fix: Make response schema for CreateBulkDownload consistent between flag on/off

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -215,6 +215,7 @@ sources:
             path: /bulk_download
             method: POST
             requestSchema: ./json-schemas/createBulkDownload.json
+            responseSchema: ./json-schemas/createBulkDownloadResponse.json
             responseTypeName: BulkDownload
           - type: Mutation
             field: DeleteSamples

--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -216,7 +216,7 @@ sources:
             method: POST
             requestSchema: ./json-schemas/createBulkDownload.json
             responseSchema: ./json-schemas/createBulkDownloadResponse.json
-            responseTypeName: BulkDownload
+            responseTypeName: fedCreateBulkDownload
           - type: Mutation
             field: DeleteSamples
             path: /samples/bulk_delete

--- a/json-schemas/createBulkDownloadResponse.json
+++ b/json-schemas/createBulkDownloadResponse.json
@@ -1,0 +1,9 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+          "type": "string"
+        }
+    },
+    "required": ["id"]
+  }

--- a/resolver-functions/CreateBulkDownload/CreateBulkDownload.test.ts
+++ b/resolver-functions/CreateBulkDownload/CreateBulkDownload.test.ts
@@ -51,9 +51,9 @@ describe.only("CreateBulkDownload Query", () => {
         workflowRunIds: [1991, 2007],
         workflowRunIdsStrings: ["1991", "2007"],
       });
-      expect(result.data.CreateBulkDownload).toStrictEqual(
-        createBulkDownloadResponse,
-      );
+      expect(result.data.CreateBulkDownload).toEqual({
+        id: "448",
+      });
     });
   });
 
@@ -115,12 +115,8 @@ describe.only("CreateBulkDownload Query", () => {
         workflowRunIds: [1991, 2007],
         workflowRunIdsStrings: ["1991", "2007"],
       });
-      expect(result.data.CreateBulkDownload).toStrictEqual({
-        data: {
-          runWorkflowVersion: {
-            id: "018e9f6b-5c95-7a0d-933f-c5ab489799f6",
-          },
-        },
+      expect(result.data.CreateBulkDownload).toEqual({
+        id: "018e9f6b-5c95-7a0d-933f-c5ab489799f6",
       });
     });
   });

--- a/resolver-functions/CreateBulkDownload/CreateBulkDownload.ts
+++ b/resolver-functions/CreateBulkDownload/CreateBulkDownload.ts
@@ -48,8 +48,8 @@ export const CreateBulkDownloadResolver = async (root, args, context, info) => {
       args,
       context,
     });
-    if (railsResponse.error_message != null) {
-      throw new Error(railsResponse.error_message);
+    if (railsResponse.error != null) {
+      throw new Error(railsResponse.error);
     }
     return {
       id: railsResponse.id.toString(),

--- a/resolver-functions/CreateBulkDownload/CreateBulkDownload.ts
+++ b/resolver-functions/CreateBulkDownload/CreateBulkDownload.ts
@@ -23,6 +23,7 @@ export const CreateBulkDownloadResolver = async (root, args, context, info) => {
     id => id && parseInt(id),
   );
   const nextGenEnabled = await shouldReadFromNextGen(context);
+
   /* --------------------- Rails --------------------- */
   if (!nextGenEnabled) {
     const body = {
@@ -49,6 +50,7 @@ export const CreateBulkDownloadResolver = async (root, args, context, info) => {
     });
     return res;
   }
+
   /* --------------------- Next Gen --------------------- */
   // get the default bulk download workflow version id from the workflow service
   if (!workflowRunIdsStrings || workflowRunIdsStrings.length === 0) {

--- a/resolver-functions/CreateBulkDownload/CreateBulkDownload.ts
+++ b/resolver-functions/CreateBulkDownload/CreateBulkDownload.ts
@@ -42,13 +42,18 @@ export const CreateBulkDownloadResolver = async (root, args, context, info) => {
       },
       workflow_run_ids: workflowRunIdsNumbers ?? workflowRunIds,
     };
-    const res = await postWithCSRF({
+    const railsResponse = await postWithCSRF({
       url: `/bulk_downloads`,
       body,
       args,
       context,
     });
-    return res;
+    if (railsResponse.error_message != null) {
+      throw new Error(railsResponse.error_message);
+    }
+    return {
+      id: railsResponse.id.toString(),
+    };
   }
 
   /* --------------------- Next Gen --------------------- */
@@ -126,11 +131,12 @@ export const CreateBulkDownloadResolver = async (root, args, context, info) => {
         }
       }
     `;
-  const res = await fetchFromNextGen({
-    args,
-    context,
-    serviceType: "workflows",
-    customQuery: runBulkDownload,
-  });
-  return res;
+  return (
+    await fetchFromNextGen({
+      args,
+      context,
+      serviceType: "workflows",
+      customQuery: runBulkDownload,
+    })
+  ).data.runWorkflowVersion;
 };

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -243,7 +243,7 @@ type BulkDownload implements EntityInterface & Node {
   downloadType: BulkDownloadType!
   file(where: FileWhereClause = null): File
   fileId: ID
-  id: ID!
+  id: String!
   ownerUserId: Int!
   producingRunId: ID
   updatedAt: DateTime
@@ -1611,7 +1611,7 @@ type MultipartUploadResponse {
 }
 
 type Mutation {
-  CreateBulkDownload(input: mutationInput_CreateBulkDownload_input_Input): JSON @httpOperation(subgraph: "CZIDREST", path: "/bulk_download", httpMethod: POST)
+  CreateBulkDownload(input: mutationInput_CreateBulkDownload_input_Input): BulkDownload @httpOperation(subgraph: "CZIDREST", path: "/bulk_download", httpMethod: POST)
   DeleteSamples(input: mutationInput_DeleteSamples_input_Input): DeleteSamples @httpOperation(subgraph: "CZIDREST", path: "/samples/bulk_delete", httpMethod: POST)
   KickoffAMRWorkflow(input: mutationInput_KickoffAMRWorkflow_input_Input, sampleId: String): [mutation_KickoffWGSWorkflow_items] @httpOperation(subgraph: "CZIDREST", path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   KickoffWGSWorkflow(input: mutationInput_KickoffWGSWorkflow_input_Input, sampleId: String): [mutation_KickoffWGSWorkflow_items] @httpOperation(subgraph: "CZIDREST", path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -243,7 +243,7 @@ type BulkDownload implements EntityInterface & Node {
   downloadType: BulkDownloadType!
   file(where: FileWhereClause = null): File
   fileId: ID
-  id: String!
+  id: ID!
   ownerUserId: Int!
   producingRunId: ID
   updatedAt: DateTime
@@ -1611,7 +1611,7 @@ type MultipartUploadResponse {
 }
 
 type Mutation {
-  CreateBulkDownload(input: mutationInput_CreateBulkDownload_input_Input): BulkDownload @httpOperation(subgraph: "CZIDREST", path: "/bulk_download", httpMethod: POST)
+  CreateBulkDownload(input: mutationInput_CreateBulkDownload_input_Input): fedCreateBulkDownload @httpOperation(subgraph: "CZIDREST", path: "/bulk_download", httpMethod: POST)
   DeleteSamples(input: mutationInput_DeleteSamples_input_Input): DeleteSamples @httpOperation(subgraph: "CZIDREST", path: "/samples/bulk_delete", httpMethod: POST)
   KickoffAMRWorkflow(input: mutationInput_KickoffAMRWorkflow_input_Input, sampleId: String): [mutation_KickoffWGSWorkflow_items] @httpOperation(subgraph: "CZIDREST", path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
   KickoffWGSWorkflow(input: mutationInput_KickoffWGSWorkflow_input_Input, sampleId: String): [mutation_KickoffWGSWorkflow_items] @httpOperation(subgraph: "CZIDREST", path: "/samples/{args.sampleId}/kickoff_workflow", operationSpecificHeaders: "{\\"Cookie\\":\\"{context.headers['cookie']}\\"}", httpMethod: POST)
@@ -3789,6 +3789,10 @@ input WorkflowWhereClauseMutations {
 type ZipLink {
   error: String
   url: String
+}
+
+type fedCreateBulkDownload {
+  id: String!
 }
 
 type fedWorkflowRunsAggregate {

--- a/utils/httpUtils.ts
+++ b/utils/httpUtils.ts
@@ -67,7 +67,11 @@ export const postWithCSRF = async ({
       body: JSON.stringify(body),
     });
     checkForLogin(response?.url);
-    return await response.json();
+    const responseJson = await response.json();
+    console.log(
+      `Rails POST to ${url} response: ${JSON.stringify(responseJson)}`,
+    );
+    return responseJson;
   } catch (e) {
     handleFetchError(e);
   }


### PR DESCRIPTION
# Pull Request

Just return the ID (not currently using any of the fields anyways) if successful.

I changed the response name so it doesn't conflict with the NextGen type.
