### PR TITLE
fix: Update NextGen schema with new errorLabel field and pass it through SampleForReport

### DIFF
--- a/example-queries/sample-for-report-query.graphql
+++ b/example-queries/sample-for-report-query.graphql
@@ -36,7 +36,10 @@ query SampleViewSampleQuery($railsSampleId: String, $snapshotLinkId: String) {
       deprecated
       executed_at
       id
-      input_error
+      input_error {
+        label
+        message
+      }
       inputs {
         accession_id
         accession_name

--- a/json-schemas/sampleForReportResponse.json
+++ b/json-schemas/sampleForReportResponse.json
@@ -113,7 +113,15 @@
                         "type": "boolean"
                     },
                     "input_error": {
-                        "type": "string"
+                        "type": "object",
+                        "properties": {
+                            "label": {
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "inputs": {
                         "type": "object",

--- a/resolver-functions/SampleForReport.ts
+++ b/resolver-functions/SampleForReport.ts
@@ -256,10 +256,13 @@ export const SampleForReportResolver = async (root, args, context) => {
         deprecated: null,
         executed_at: workflowRun.createdAt,
         id: workflowRun.id,
-        input_error: {
-          label: workflowRun.errorLabel,
-          message: workflowRun.errorMessage,
-        },
+        input_error:
+          workflowRun.errorLabel != null || workflowRun.errorMessage != null
+            ? {
+                label: workflowRun.errorLabel,
+                message: workflowRun.errorMessage,
+              }
+            : undefined,
         inputs: {
           accession_id: accession?.accessionId,
           accession_name: accession?.accessionName,

--- a/sample-responses/sampleForReport.json
+++ b/sample-responses/sampleForReport.json
@@ -36,7 +36,10 @@
           "wdl_version": "3.4.18",
           "executed_at": "2023-10-17T07:10:33.000-07:00",
           "deprecated": false,
-          "input_error": "hi",
+          "input_error": {
+            "label": "InsufficientReadsError",
+            "message": "There were not enough reads."
+          },
           "inputs": {
               "accession_id": "11",
               "accession_name": "11",

--- a/tests/SampleForReportQuery.test.ts
+++ b/tests/SampleForReportQuery.test.ts
@@ -46,7 +46,10 @@ describe("SampleForReport query:", () => {
         wdl_version: "3.5.0",
         executed_at: "2024-02-29T15:09:11.000-08:00",
         deprecated: false,
-        input_error: null,
+        input_error: {
+          label: "Error label",
+          message: "Error message",
+        },
         inputs: {
           accession_id: "MN908947.3",
           accession_name:
@@ -124,7 +127,10 @@ describe("SampleForReport query:", () => {
             deprecated: false,
             executed_at: "2024-02-29T15:09:11.000-08:00",
             id: "7126",
-            input_error: null,
+            input_error: {
+              label: "Error label",
+              message: "Error message",
+            },
             inputs: {
               accession_id: "MN908947.3",
               accession_name:
@@ -196,7 +202,8 @@ describe("SampleForReport query:", () => {
             railsWorkflowRunId: 7126,
             status: "SUCCEEDED",
             ownerUserId: 345,
-            errorMessage: null,
+            errorLabel: "Error label",
+            errorMessage: "Error message",
             workflowVersion: {
               version: "3.5.0",
               id: "018df6ca-d3c0-7edd-a243-4127e06eb1d1",
@@ -207,16 +214,16 @@ describe("SampleForReport query:", () => {
                 {
                   node: {
                     inputEntityId: "018ded47-34ac-7f3a-9dff-a43e5036393a",
-                    entityType: "taxon"
+                    entityType: "taxon",
                   },
                 },
                 {
                   node: {
                     inputEntityId: "def",
-                    entityType: "accession"
-                  }
-                }
-              ]
+                    entityType: "accession",
+                  },
+                },
+              ],
             },
             createdAt: "2024-02-29T23:09:10.470257+00:00",
             endedAt: null,
@@ -234,9 +241,9 @@ describe("SampleForReport query:", () => {
             id: "018ded47-34ac-7f3a-9dff-a43e5036393a",
             name: "Severe acute respiratory syndrome coronavirus 2",
             upstreamDatabaseIdentifier: "2697049",
-          }
+          },
         ],
-      }
+      },
     }));
     (httpUtils.get as jest.Mock).mockImplementationOnce(() => ({
       data: {
@@ -244,10 +251,11 @@ describe("SampleForReport query:", () => {
           {
             id: "def",
             accessionId: "MN908947.3",
-            accessionName: "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
-          }
+            accessionName:
+              "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
+          },
         ],
-      }
+      },
     }));
 
     const result = await execute(query, {
@@ -281,7 +289,10 @@ describe("SampleForReport query:", () => {
             deprecated: null,
             executed_at: "2024-02-29T23:09:10.470257+00:00",
             id: "018df720-fbd6-77f9-9b4a-1ca468d5207f",
-            input_error: null,
+            input_error: {
+              label: "Error label",
+              message: "Error message",
+            },
             inputs: {
               accession_id: "MN908947.3",
               accession_name:
@@ -353,16 +364,16 @@ describe("SampleForReport query:", () => {
                 {
                   node: {
                     inputEntityId: "018ded47-34ac-7f3a-9dff-a43e5036393a",
-                    entityType: "taxon"
+                    entityType: "taxon",
                   },
                 },
                 {
                   node: {
                     inputEntityId: "def",
-                    entityType: "accession"
-                  }
-                }
-              ]
+                    entityType: "accession",
+                  },
+                },
+              ],
             },
             createdAt: "2024-02-29T23:09:10.470257+00:00",
             endedAt: null,
@@ -380,9 +391,9 @@ describe("SampleForReport query:", () => {
             id: "018ded47-34ac-7f3a-9dff-a43e5036393a",
             name: "Severe acute respiratory syndrome coronavirus 2",
             upstreamDatabaseIdentifier: "2697049",
-          }
+          },
         ],
-      }
+      },
     }));
     (httpUtils.get as jest.Mock).mockImplementationOnce(() => ({
       data: {
@@ -390,10 +401,11 @@ describe("SampleForReport query:", () => {
           {
             id: "def",
             accessionId: "MN908947.3",
-            accessionName: "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
-          }
+            accessionName:
+              "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
+          },
         ],
-      }
+      },
     }));
 
     const result = await execute(query, {

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -4724,13 +4724,18 @@ type query_SampleForReport_workflow_runs_items {
   deprecated: Boolean
   executed_at: String!
   id: String!
-  input_error: String
+  input_error: query_SampleForReport_workflow_runs_items_input_error
   inputs: query_SampleForReport_workflow_runs_items_inputs!
   rails_workflow_run_id: String
   run_finalized: Boolean!
   status: String
   wdl_version: String
   workflow: String
+}
+
+type query_SampleForReport_workflow_runs_items_input_error {
+  label: String
+  message: String
 }
 
 type query_SampleForReport_workflow_runs_items_inputs {


### PR DESCRIPTION
# Pull Request

What was previously returned by NextGen as `errorMessage` should've actually been the label. Now there is an `errorLabel` field and `errorMessage` contains the actual sentence explaining the error. Pass these down to the sample report in an object to what Rails returns (and what the FE expects) today.
