### PR TITLE
feat: Expose errorLabel in fedWorkflowRuns

### DIFF
--- a/json-schemas/workflowRunsResponse.json
+++ b/json-schemas/workflowRunsResponse.json
@@ -15,6 +15,12 @@
             "status": {
                 "type": "string"
             },
+            "errorLabel": {
+                "type": "string"
+            },
+            "errorMessage": {
+                "type": "string"
+            },
             "rawInputsJson": {
                 "type": "string"
             },

--- a/json-schemas/workflowRunsResponse.json
+++ b/json-schemas/workflowRunsResponse.json
@@ -18,9 +18,6 @@
             "errorLabel": {
                 "type": "string"
             },
-            "errorMessage": {
-                "type": "string"
-            },
             "rawInputsJson": {
                 "type": "string"
             },

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -5217,6 +5217,7 @@ type query_fedWorkflowRunsAggregate_aggregate_items_groupBy_workflowVersion_work
 
 type query_fedWorkflowRuns_items {
   entityInputs: query_fedWorkflowRuns_items_entityInputs!
+  errorLabel: String
   id: String!
   ownerUserId: Int!
   rawInputsJson: String


### PR DESCRIPTION
# Pull Request

This will be used by the FE to alter `status` since NextGen does not have the capability to do so.
