### PR TITLE
chore: Update comment

### DIFF
--- a/resolver-functions/fedSequencingReads/fedSequencingReads.ts
+++ b/resolver-functions/fedSequencingReads/fedSequencingReads.ts
@@ -213,7 +213,7 @@ export const fedSequencingReadsResolver = async (root, args, context: any) => {
           : input.limit ?? input.limitOffset?.limit, // TODO: Just use limitOffset.
         offset: queryingIdsOnly ? 0 : input.offset ?? input.limitOffset?.offset,
         listAllIds: false,
-        workflowRunIds: input.consensusGenomesInput?.where?.producingRunId?._in,
+        workflowRunIds: input?.todoRemove?.workflowRunIds,
         // Only used for API testing:
         sampleIds: input?.todoRemove?.sampleIds,
       }),

--- a/resolver-functions/fedSequencingReads/fedSequencingReads.ts
+++ b/resolver-functions/fedSequencingReads/fedSequencingReads.ts
@@ -213,8 +213,8 @@ export const fedSequencingReadsResolver = async (root, args, context: any) => {
           : input.limit ?? input.limitOffset?.limit, // TODO: Just use limitOffset.
         offset: queryingIdsOnly ? 0 : input.offset ?? input.limitOffset?.offset,
         listAllIds: false,
-        // workflowRunIds and sampleIds are only used for API testing.
-        workflowRunIds: input?.todoRemove?.workflowRunIds,
+        workflowRunIds: input.consensusGenomesInput?.where?.producingRunId?._in,
+        // Only used for API testing:
         sampleIds: input?.todoRemove?.sampleIds,
       }),
     args,


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9565]

## Description

I will start using `workflowRunIds` in order to ensure that the call for IDs and the call for rows are aligned (instead of assuming that /workflow_runs.json will return the same sequence of runs each time, which is technically not guaranteed since a new run may be created in between the different calls).


[CZID-9565]: https://czi-tech.atlassian.net/browse/CZID-9565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ