### PR TITLE
fix: Always stringify object query params

### DIFF
--- a/resolver-functions/fedSequencingReads/fedSequencingReads.ts
+++ b/resolver-functions/fedSequencingReads/fedSequencingReads.ts
@@ -213,8 +213,8 @@ export const fedSequencingReadsResolver = async (root, args, context: any) => {
           : input.limit ?? input.limitOffset?.limit, // TODO: Just use limitOffset.
         offset: queryingIdsOnly ? 0 : input.offset ?? input.limitOffset?.offset,
         listAllIds: false,
-        // workflowRunIds and sampleIds are only used for API testing.
         workflowRunIds: input?.todoRemove?.workflowRunIds,
+        // Only used for API testing:
         sampleIds: input?.todoRemove?.sampleIds,
       }),
     args,

--- a/tests/ParamsUtils.test.ts
+++ b/tests/ParamsUtils.test.ts
@@ -2,13 +2,29 @@ import { formatUrlParams } from "../utils/paramsUtils";
 
 describe("ParamsUtils:", () => {
   describe("formatUrlParams:", () => {
-    it("Returns empty string", () => {
+    it("Handles basic types", () => {
       expect(
         formatUrlParams({
           param1: 123,
           param2: "456",
         }),
       ).toBe("?&param1=123&param2=456");
+    });
+
+    it("Handles spaces in strings", () => {
+      expect(
+        formatUrlParams({
+          param2: "456 789",
+        }),
+      ).toBe("?&param2=456+789");
+    });
+
+    it("Handles objects", () => {
+      expect(
+        formatUrlParams({
+          param1: { name: "Not a hit" },
+        }),
+      ).toBe('?&param1={"name":"Not a hit"}');
     });
 
     it("Filters out nullishes", () => {
@@ -22,7 +38,7 @@ describe("ParamsUtils:", () => {
       ).toBe("?&param1=123&param4=456");
     });
 
-    it("Handles arrays of strings", () => {
+    it("Handles arrays", () => {
       expect(
         formatUrlParams({
           param1: [123, 456],
@@ -39,15 +55,6 @@ describe("ParamsUtils:", () => {
       ).toBe(
         '?&param1[]={"name":"Not a hit"}&param1[]={"name":"Inconclusive"}',
       );
-    });
-
-    it("Handles Spaces in strings", () => {
-      expect(
-        formatUrlParams({
-          param1: 123,
-          param2: "456 789",
-        }),
-      ).toBe("?&param1=123&param2=456+789");
     });
   });
 });

--- a/tests/ParamsUtils.test.ts
+++ b/tests/ParamsUtils.test.ts
@@ -7,7 +7,7 @@ describe("ParamsUtils:", () => {
         formatUrlParams({
           param1: 123,
           param2: "456",
-        })
+        }),
       ).toBe("?&param1=123&param2=456");
     });
 
@@ -18,17 +18,27 @@ describe("ParamsUtils:", () => {
           param2: undefined,
           param3: null,
           param4: 456,
-        })
+        }),
       ).toBe("?&param1=123&param4=456");
     });
 
-    it("Handles arrays", () => {
+    it("Handles arrays of strings", () => {
       expect(
         formatUrlParams({
           param1: [123, 456],
           param2: [],
-        })
+        }),
       ).toBe("?&param1[]=123&param1[]=456");
+    });
+
+    it("Handles arrays of objects", () => {
+      expect(
+        formatUrlParams({
+          param1: [{ name: "Not a hit" }, { name: "Inconclusive" }],
+        }),
+      ).toBe(
+        '?&param1[]={"name":"Not a hit"}&param1[]={"name":"Inconclusive"}',
+      );
     });
 
     it("Handles Spaces in strings", () => {
@@ -36,7 +46,7 @@ describe("ParamsUtils:", () => {
         formatUrlParams({
           param1: 123,
           param2: "456 789",
-        })
+        }),
       ).toBe("?&param1=123&param2=456+789");
     });
   });

--- a/utils/paramsUtils.ts
+++ b/utils/paramsUtils.ts
@@ -14,10 +14,13 @@ export const formatUrlParams = (params: { [s: string]: unknown }) => {
     .filter(([_, value]) => value != null)
     .flatMap(([key, value]) =>
       Array.isArray(value)
-        ? value.map(arrayElement => `${key}[]=${JSON.stringify(arrayElement)}`)
+        ? value.map(
+            arrayElement =>
+              `${key}[]=${typeof arrayElement === "object" ? JSON.stringify(arrayElement) : arrayElement}`,
+          )
         : typeof value === "string"
           ? [`${key}=${replaceSpaces(value)}`]
-          : [`${key}=${JSON.stringify(value)}`],
+          : [`${key}=${value}`],
     );
   if (paramList.length === 0) {
     return "";

--- a/utils/paramsUtils.ts
+++ b/utils/paramsUtils.ts
@@ -20,7 +20,9 @@ export const formatUrlParams = (params: { [s: string]: unknown }) => {
           )
         : typeof value === "string"
           ? [`${key}=${replaceSpaces(value)}`]
-          : [`${key}=${value}`],
+          : typeof value === "object"
+            ? [`${key}=${JSON.stringify(value)}`]
+            : [`${key}=${value}`],
     );
   if (paramList.length === 0) {
     return "";

--- a/utils/paramsUtils.ts
+++ b/utils/paramsUtils.ts
@@ -7,17 +7,17 @@
 
 export const formatUrlParams = (params: { [s: string]: unknown }) => {
   const replaceSpaces = (value: string) => {
-    const safeString = value.split(' ').join('+');
+    const safeString = value.split(" ").join("+");
     return safeString;
-  }
+  };
   const paramList = Object.entries(params)
     .filter(([_, value]) => value != null)
     .flatMap(([key, value]) =>
       Array.isArray(value)
-        ? value.map((arrayElement) => `${key}[]=${arrayElement}`)
+        ? value.map(arrayElement => `${key}[]=${JSON.stringify(arrayElement)}`)
         : typeof value === "string"
           ? [`${key}=${replaceSpaces(value)}`]
-          : [`${key}=${value}`]
+          : [`${key}=${JSON.stringify(value)}`],
     );
   if (paramList.length === 0) {
     return "";


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9676]

## Description

Prevents object URL params being sent as `[object Object]`.

[CZID-9676]: https://czi-tech.atlassian.net/browse/CZID-9676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ