### PR TITLE
feat: add pinned_alignment_config to SampleForReportResponse

### DIFF
--- a/json-schemas/sampleForReportResponse.json
+++ b/json-schemas/sampleForReportResponse.json
@@ -42,6 +42,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "pinned_alignment_config": {
+                    "type": "string"
                 }
             }
         },

--- a/tests/__snapshots__/UnifiedSchema.test.ts.snap
+++ b/tests/__snapshots__/UnifiedSchema.test.ts.snap
@@ -4492,6 +4492,7 @@ type query_SampleForReport_pipeline_runs_items {
 type query_SampleForReport_project {
   id: String
   name: String
+  pinned_alignment_config: String
 }
 
 type query_SampleForReport_workflow_runs_items {


### PR DESCRIPTION
# Pull Request

## JIRA Ticket

[CZID-9618]

## Description
added pinned_alignment_config to response so that we can kick off CG reports from mNGS page with pinned value rather than using the workflow run inputs. 

## Notes

*Optional observations, comments or explanations.*
*If implementing a new feature, note any relevant analytics added.*

## Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*


[CZID-9618]: https://czi-tech.atlassian.net/browse/CZID-9618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ