### PR TITLE
fix: add initial_delay_seconds in terraform

### DIFF
--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -35,13 +35,14 @@ module "stack" {
   k8s_namespace    = var.k8s_namespace
   services = {
     gql = merge(local.routing_config[local.service_type], {
-      name              = "graphql-federation"
-      port              = "4444"
-      memory            = "8000Mi"
-      memory_requests   = "8000Mi"
-      cpu               = "3000m"
-      cpu_requests      = "3000m"
-      health_check_path = "/health"
+      name                   = "graphql-federation"
+      port                   = "4444"
+      memory                 = "8000Mi"
+      memory_requests        = "8000Mi"
+      cpu                    = "3000m"
+      cpu_requests           = "3000m"
+      initial_delay_seconds  = "120"
+      health_check_path      = "/health"
       // INTERNAL - OIDC protected ALB
       // EXTERNAL - external ALB
       // PRIVATE - cluster IP only, no ALB at all

--- a/.happy/terraform/envs/sandbox/main.tf
+++ b/.happy/terraform/envs/sandbox/main.tf
@@ -35,13 +35,14 @@ module "stack" {
   k8s_namespace    = var.k8s_namespace
   services = {
     gql = merge(local.routing_config[local.service_type], {
-      name              = "graphql-federation"
-      port              = "4444"
-      memory            = "8000Mi"
-      memory_requests   = "8000Mi"
-      cpu               = "3000m"
-      cpu_requests      = "3000m"
-      health_check_path = "/health"
+      name                  = "graphql-federation"
+      port                  = "4444"
+      memory                = "8000Mi"
+      memory_requests       = "8000Mi"
+      cpu                   = "3000m"
+      cpu_requests          = "3000m"
+      initial_delay_seconds = "120"
+      health_check_path     = "/health"
       // INTERNAL - OIDC protected ALB
       // EXTERNAL - external ALB
       // PRIVATE - cluster IP only, no ALB at all

--- a/.happy/terraform/envs/staging/main.tf
+++ b/.happy/terraform/envs/staging/main.tf
@@ -35,16 +35,14 @@ module "stack" {
   k8s_namespace    = var.k8s_namespace
   services = {
     gql = merge(local.routing_config[local.service_type], {
-      name                      = "graphql-federation"
-      port                      = "4444"
-      memory                    = "8000Mi"
-      memory_requests           = "8000Mi"
-      cpu                       = "3000m"
-      cpu_requests              = "3000m"
-      initial_delay_seconds     = "120"
-      liveness_timeout_seconds  = "180"
-      readiness_timeout_seconds = "180"
-      health_check_path         = "/health"
+      name                  = "graphql-federation"
+      port                  = "4444"
+      memory                = "8000Mi"
+      memory_requests       = "8000Mi"
+      cpu                   = "3000m"
+      cpu_requests          = "3000m"
+      initial_delay_seconds = "120"
+      health_check_path     = "/health"
       // INTERNAL - OIDC protected ALB
       // EXTERNAL - external ALB
       // PRIVATE - cluster IP only, no ALB at all

--- a/.happy/terraform/envs/staging/main.tf
+++ b/.happy/terraform/envs/staging/main.tf
@@ -41,6 +41,7 @@ module "stack" {
       memory_requests           = "8000Mi"
       cpu                       = "3000m"
       cpu_requests              = "3000m"
+      initial_delay_seconds     = "120"
       liveness_timeout_seconds  = "180"
       readiness_timeout_seconds = "180"
       health_check_path         = "/health"


### PR DESCRIPTION
As discovered by @jakeyheath, the app in staging takes around 80 seconds to start, so health checks start to fail before that.  Configuring `initial_delay_seconds` allows the server to start up before health checks begin.  This PR adds the config for sandbox, staging and prod.