### PR TITLE
fix: Remove unsupported healthCheckEndpoint config

### DIFF
--- a/.meshrc.yaml
+++ b/.meshrc.yaml
@@ -252,7 +252,6 @@ plugins:
 serve:
   port: 4444
   endpoint: "/graphqlfed"
-  healthCheckEndpoint: "/health"
   playground: true
   cors:
     origin: "${ALLOWED_CORS_ORIGINS}"


### PR DESCRIPTION
`healthCheckEndpoint` is not supposed in our version of graphql mesh

including it in config actually causes a warning when running `mesh build`

```
> mesh build

🕸️  Mesh 💡 Cleaning existing artifacts
🕸️  Mesh 💡 Reading the configuration
🕸️  Mesh - config ⚠️ Configuration file is not valid!
🕸️  Mesh - config ⚠️ This is just a warning! It doesn't have any effects on runtime.
🕸️  Mesh - config ⚠️ Error: must NOT have additional properties
🕸️  Mesh 💡 Generating the unified schema
```